### PR TITLE
Static Ipv4 for docker containers

### DIFF
--- a/.devcontainer/virtual/docker-compose.yml
+++ b/.devcontainer/virtual/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - ~/.gitconfig:/home/docker/.gitconfig
       - $DOCKER_ENV_DIR/.bash_history:/home/docker/.bash_history
     user: ${HOST_UID:-1000}:${HOST_UID:-1000}
+    networks:
+      virt-cybics:
+        ipv4_address: 172.18.1.100
 
   openplc:
     image: mniedermaier1337/cybicsopenplc:latest
@@ -24,6 +27,9 @@ services:
     ports:
       - 8080:8080
       - 502:502
+    networks:
+      virt-cybics:
+        ipv4_address: 172.18.1.3
 
   opcua:
     image: mniedermaier1337/cybicsopcua:latest
@@ -35,6 +41,9 @@ services:
       - 4840:4840
     depends_on:
     - openplc
+    networks:
+      virt-cybics:
+        ipv4_address: 172.18.1.5
 
   s7com:
     image: mniedermaier1337/cybicss7comlatest
@@ -46,6 +55,9 @@ services:
       - 102:102
     depends_on:
     - openplc
+    networks:
+      virt-cybics:
+        ipv4_address: 172.18.1.6
 
   fuxa:
     image: mniedermaier1337/cybicsfuxa:latest
@@ -57,6 +69,9 @@ services:
       - 1881:1881
     depends_on:
     - openplc
+    networks:
+      virt-cybics:
+        ipv4_address: 172.18.1.4
 
   hwio:
     image: mniedermaier1337/cybicshwio:latest
@@ -68,3 +83,16 @@ services:
       - 80:8090
     depends_on:
     - openplc
+    networks:
+      virt-cybics:
+        ipv4_address: 172.18.1.2
+
+networks:
+  virt-cybics:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.1.0/24
+          gateway: 172.18.1.1
+

--- a/.devcontainer/virtual/docker-compose.yml
+++ b/.devcontainer/virtual/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     user: ${HOST_UID:-1000}:${HOST_UID:-1000}
     networks:
       virt-cybics:
-        ipv4_address: 172.18.1.100
+        ipv4_address: 172.18.0.100
 
   openplc:
     image: mniedermaier1337/cybicsopenplc:latest
@@ -29,7 +29,7 @@ services:
       - 502:502
     networks:
       virt-cybics:
-        ipv4_address: 172.18.1.3
+        ipv4_address: 172.18.0.3
 
   opcua:
     image: mniedermaier1337/cybicsopcua:latest
@@ -43,7 +43,7 @@ services:
     - openplc
     networks:
       virt-cybics:
-        ipv4_address: 172.18.1.5
+        ipv4_address: 172.18.0.5
 
   s7com:
     image: mniedermaier1337/cybicss7comlatest
@@ -57,7 +57,7 @@ services:
     - openplc
     networks:
       virt-cybics:
-        ipv4_address: 172.18.1.6
+        ipv4_address: 172.18.0.6
 
   fuxa:
     image: mniedermaier1337/cybicsfuxa:latest
@@ -71,7 +71,7 @@ services:
     - openplc
     networks:
       virt-cybics:
-        ipv4_address: 172.18.1.4
+        ipv4_address: 172.18.0.4
 
   hwio:
     image: mniedermaier1337/cybicshwio:latest
@@ -85,7 +85,7 @@ services:
     - openplc
     networks:
       virt-cybics:
-        ipv4_address: 172.18.1.2
+        ipv4_address: 172.18.0.2
 
 networks:
   virt-cybics:
@@ -93,6 +93,6 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.18.1.0/24
-          gateway: 172.18.1.1
+        - subnet: 172.18.0.0/24
+          gateway: 172.18.0.1
 

--- a/software/docker-compose.yaml
+++ b/software/docker-compose.yaml
@@ -9,7 +9,8 @@ services:
     volumes:
       - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     networks:
-      - br-cybics
+      br-cybics:
+        ipv4_address: 172.18.0.2
 
   opcua:
     image: localhost:5000/cybics-opcua:latest
@@ -19,7 +20,8 @@ services:
     ports:
       - 4840:4840
     networks:
-      - br-cybics
+      br-cybics:
+        ipv4_address: 172.18.0.5
 
   s7com:
     image: localhost:5000/cybics-s7com:latest
@@ -29,7 +31,8 @@ services:
     ports:
       - 102:102
     networks:
-      - br-cybics
+      br-cybics:
+        ipv4_address: 172.18.0.6
 
   openplc:
     image: localhost:5000/cybics-openplc:latest
@@ -42,7 +45,8 @@ services:
       - 8080:8080
       - 502:502
     networks:
-      - br-cybics
+      br-cybics:
+        ipv4_address: 172.18.0.3
 
   fuxa:
     image: localhost:5000/cybics-fuxa:latest
@@ -52,7 +56,8 @@ services:
     ports:
       - 1881:1881
     networks:
-      - br-cybics
+      br-cybics:
+        ipv4_address: 172.18.0.4
 
   stm32:
     image: localhost:5000/cybics-stm32:latest
@@ -67,3 +72,8 @@ networks:
     driver: bridge
     driver_opts:
       com.docker.network.bridge.name: br-cybics
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.18.0.0/24
+          gateway: 1172.18.0.1


### PR DESCRIPTION
Static IPv4 addresses for all docker containers as prework for IDS integration.

The virtual version is tested,. I had no possibility to test the hardware one at the momment.

Subnet:
172.18.0.0/24 -> Hardware
172.18.1.0/24 -> Virtual

Hosts:
.1 -> Gateway
.2 -> hwio
.3 -> openplc
.4 -> fuxa
.5 -> opcua
.6 -> s7com