### PR TITLE
Fix STM32 devcontainer build: upgrade pip/setuptools/wheel first

### DIFF
--- a/.devcontainer/stm32/Dockerfile
+++ b/.devcontainer/stm32/Dockerfile
@@ -56,8 +56,9 @@ RUN python3 -m venv .venv
 ENV PATH=/home/docker/zephyrproject/.venv/bin:$PATH
 ENV VIRTUAL_ENV=/home/docker/zephyrproject/.venv
 
-# Install west and pre-pin packages in virtual environment
-RUN pip install west
+# Install west in virtual environment
+RUN pip install --upgrade pip setuptools wheel && \
+    pip install west
 
 # Initialize workspace using manifest (downloads only required modules)
 RUN west init -l app && \


### PR DESCRIPTION
The ruamel.yaml.clibz package (a west dependency) requires modern build tools. Upgrading pip, setuptools, and wheel before installing west is standard Python practice and ensures packages can be built from source.
