### PR TITLE
Fix detach button for VNC services (Engineering WS, Attack Machine)

### DIFF
--- a/software/landing/templates/index.html
+++ b/software/landing/templates/index.html
@@ -2016,15 +2016,13 @@
             if (!config) return;
 
             let url;
-            if (config.path) {
-                // For CTF and Tools, use relative path
-                if (config.path.startsWith('/')) {
-                    url = config.path;
-                } else {
-                    // For services with ports
-                    const hostname = window.location.hostname;
-                    url = `http://${hostname}:${config.port}${config.path}`;
-                }
+            if (config.path && config.port) {
+                // For services with both path and port (e.g., VNC services)
+                const hostname = window.location.hostname;
+                url = `http://${hostname}:${config.port}${config.path}`;
+            } else if (config.path) {
+                // For local paths without ports (CTF, Tools)
+                url = config.path;
             } else if (config.port) {
                 // For services with just ports
                 const hostname = window.location.hostname;


### PR DESCRIPTION
The detach button was incorrectly using relative paths for VNC services, resulting in 404 errors. Now properly constructs full URL with port when both path and port are configured.