### PR TITLE
Fix markdown documentation consistency issues

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -262,7 +262,7 @@ If the AI Agent shows as unavailable:
 
 - Explore the [Training Modules](../training/) for hands-on cybersecurity scenarios
 - Review the [Software Documentation](../software/) for detailed component information
-- Join our community and contribute on [GitHub](https://github.com/hsainnos/CybICS)
+- Join our community and contribute on [GitHub](https://github.com/mniedermaier/CybICS)
 
 ## License
 

--- a/software/FUXA/README.md
+++ b/software/FUXA/README.md
@@ -1,6 +1,9 @@
+# FUXA HMI
+
+## Overview
+FUXA is a web-based SCADA/HMI interface for monitoring and controlling the industrial process.
+
 ## Usage
-
-
 FUXA is running on port 1881.
 
 ## Users
@@ -97,3 +100,9 @@ Make a pretty version of the FUXA project file:
 ```sh
 jq . fuxa-project.json > fuxa-project-pretty.json
 ```
+
+## Related Documentation
+- [OpenPLC Integration](../OpenPLC/README.md)
+- [Virtual Hardware I/O](../hwio-virtual/README.md)
+- [Raspberry Pi Hardware I/O](../hwio-raspberry/README.md)
+- [Getting Started Guide](../../doc/README.md)

--- a/software/opcua/README.md
+++ b/software/opcua/README.md
@@ -1,4 +1,9 @@
-### Configuration
+# OPC UA Server
+
+## Overview
+The OPC UA server provides an OPC Unified Architecture interface for industrial communication. It enables secure and reliable data exchange between clients and the CybICS platform.
+
+## Configuration
 
 Generate user hmac sha256:
 ```sh
@@ -14,3 +19,8 @@ Convert pem to der format:
 ```sh
 openssl x509 -in cert_admin.pem -out cert_admin.der -outform DER
 ```
+
+## Related Documentation
+- [OpenPLC Integration](../OpenPLC/README.md)
+- [OPC UA Training Module](../../training/opcua/README.md)
+- [Getting Started Guide](../../doc/README.md)

--- a/training/opcua/README.md
+++ b/training/opcua/README.md
@@ -85,7 +85,7 @@ The flag has the format `CybICS(flag)`.
   ```
 
   Username: user1
-  Passwort: test
+  Password: test
   
   <div style="color:orange;font-weight: 900">
     🚩 Flag: CybICS(OPC-UA)

--- a/training/physical_process/README.md
+++ b/training/physical_process/README.md
@@ -35,7 +35,7 @@ To get the flag, the blowout needs to be triggered.
   After login on the FUXA dashboard switch to the "System" view.
   By closing the "System Valve" (SV) and enabling the Compressor (C),
   the pressure is rising.
-  After a certain time, the pressure in the High Pressure Tank (HTB)
+  After a certain time, the pressure in the High Pressure Tank (HPT)
   gets a critical level and the Blowout (BO) will be opened.
 
   <div style="color:orange;font-weight: 900">

--- a/training/scanning2/README.md
+++ b/training/scanning2/README.md
@@ -1,6 +1,6 @@
 # 🔍 S7 Communication Scanning Guide
 
-## 📋 Introduction
+## 📋 Overview
 Siemens **S7 Communication (S7comm)** typically operates on **port 102**, but can also run on custom ports. In this environment, the S7 service runs on **port 1102**. Nmap provides an **NSE script (`s7-info`)** to scan for and retrieve information from **S7 PLCs**.
 
 ## ⚙️ Prerequisites


### PR DESCRIPTION
- Fix GitHub URL in doc/README.md (hsainnos -> mniedermaier)
- Fix typo "HTB" -> "HPT" in training/physical_process/README.md
- Fix typo "Passwort" -> "Password" in training/opcua/README.md
- Add main heading and overview to software/FUXA/README.md
- Add main heading and overview to software/opcua/README.md
- Standardize "Introduction" -> "Overview" in training/scanning2/README.md
- Add Related Documentation sections to FUXA and OPC UA READMEs