### PR TITLE
Split Docker builds into native amd64 + arm64 jobs

### DIFF
--- a/.github/workflows/pushDockerRepos.yml
+++ b/.github/workflows/pushDockerRepos.yml
@@ -3,105 +3,197 @@ name: Build and Push Docker Image to Docker Hub
 on:
   push:
     branches: [ main ]
-    
+
+env:
+  IMAGES: >-
+    cybics-attack-machine:software/attack-machine:software/attack-machine/Dockerfile
+    cybicsopenplc:software/OpenPLC:software/OpenPLC/Dockerfile
+    cybicsopcua:software/opcua:software/opcua/Dockerfile
+    cybicss7com:software/s7com:software/s7com/Dockerfile
+    cybicsfuxa:software/FUXA:software/FUXA/Dockerfile
+    cybicshwio:software/hwio-virtual:software/hwio-virtual/Dockerfile
+    landing:.:software/landing/Dockerfile
+    cybics-engineeringws:software:software/engineeringWS/Dockerfile
+    cybicsagent:software/cybicsagent:software/cybicsagent/Dockerfile
+    cybics-ids:software/ids:software/ids/Dockerfile
+
 jobs:
-  linux_amd64_push_to_registry:
-    name: (linux/amd64) push docker image to hub
+  # ==== Build amd64 natively on x86 runner ====
+  build-amd64:
+    name: Build amd64 images
     runs-on: ubuntu-latest
     steps:
       - name: Free up disk space
         run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker system prune -af
           df -h
 
-      - name: check repository
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: login to docker registry
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{secrets.DOCKERHUB_USERNAME}}
-          password: ${{secrets.DOCKERHUB_TOKEN}}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: "Create environment files"
+      - name: Create environment files
         run: .devcontainer/prepare-env.sh
 
       - name: Extract version metadata
         id: meta
         run: |
-          # Get short SHA for versioning
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-          # Check if this commit is tagged (for releases)
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=${SHA_SHORT}" >> $GITHUB_OUTPUT
           GIT_TAG=$(git describe --exact-match --tags 2>/dev/null || echo "")
           echo "git_tag=${GIT_TAG}" >> $GITHUB_OUTPUT
 
-          # Create tag list: always include latest and SHA, optionally include git tag
-          if [ -n "$GIT_TAG" ]; then
-            # Remove 'v' prefix if present for Docker tag
-            VERSION_TAG=${GIT_TAG#v}
-            echo "tags=latest,$(git rev-parse --short HEAD),${VERSION_TAG}" >> $GITHUB_OUTPUT
-            echo "Building release version: ${GIT_TAG}"
-          else
-            echo "tags=latest,$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-            echo "Building development version"
-          fi
-
-      - name: Build and push docker images to registry
+      - name: Build and push amd64 images
         env:
           SHA_SHORT: ${{ steps.meta.outputs.sha_short }}
           GIT_TAG: ${{ steps.meta.outputs.git_tag }}
         run: |
-          # Create a new builder instance
-          docker buildx create --name multiarch-builder --use || true
+          for entry in $IMAGES; do
+            IFS=':' read -r NAME CONTEXT DOCKERFILE <<< "$entry"
+            IMAGE="mniedermaier1337/${NAME}"
 
-          # Helper function to build and push with multiple tags
-          build_and_push() {
-            local IMAGE_NAME=$1
-            local CONTEXT=$2
-            local DOCKERFILE=$3
-
-            # Build tag arguments
-            TAG_ARGS=""
+            TAG_ARGS="-t ${IMAGE}:${SHA_SHORT}-amd64 -t ${IMAGE}:latest-amd64"
             if [ -n "$GIT_TAG" ]; then
               VERSION_TAG=${GIT_TAG#v}
-              TAG_ARGS="-t ${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${SHA_SHORT} -t ${IMAGE_NAME}:${VERSION_TAG}"
-              echo "Building ${IMAGE_NAME} with tags: latest, ${SHA_SHORT}, ${VERSION_TAG}"
-            else
-              TAG_ARGS="-t ${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${SHA_SHORT}"
-              echo "Building ${IMAGE_NAME} with tags: latest, ${SHA_SHORT}"
+              TAG_ARGS="${TAG_ARGS} -t ${IMAGE}:${VERSION_TAG}-amd64"
             fi
 
-            # Build and push
+            echo "::group::Building ${NAME} (amd64)"
             docker buildx build \
-              --platform linux/amd64,linux/arm64 \
+              --platform linux/amd64 \
               ${TAG_ARGS} \
               --push \
               -f ${DOCKERFILE} \
               ${CONTEXT}
-          }
+            echo "::endgroup::"
+          done
 
-          # Build and push all images
-          build_and_push "mniedermaier1337/cybics-attack-machine" "software/attack-machine" "software/attack-machine/Dockerfile"
-          build_and_push "mniedermaier1337/cybicsopenplc" "software/OpenPLC" "software/OpenPLC/Dockerfile"
-          build_and_push "mniedermaier1337/cybicsopcua" "software/opcua" "software/opcua/Dockerfile"
-          build_and_push "mniedermaier1337/cybicss7com" "software/s7com" "software/s7com/Dockerfile"
-          build_and_push "mniedermaier1337/cybicsfuxa" "software/FUXA" "software/FUXA/Dockerfile"
-          build_and_push "mniedermaier1337/cybicshwio" "software/hwio-virtual" "software/hwio-virtual/Dockerfile"
-          build_and_push "mniedermaier1337/landing" "." "software/landing/Dockerfile"
-          build_and_push "mniedermaier1337/cybics-engineeringws" "software" "software/engineeringWS/Dockerfile"
-          build_and_push "mniedermaier1337/cybicsagent" "software/cybicsagent" "software/cybicsagent/Dockerfile"
-          build_and_push "mniedermaier1337/cybics-ids" "software/ids" "software/ids/Dockerfile"
+  # ==== Build arm64 natively on ARM runner ====
+  build-arm64:
+    name: Build arm64 images
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker system prune -af
+          df -h
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create environment files
+        run: .devcontainer/prepare-env.sh
+
+      - name: Extract version metadata
+        id: meta
+        run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=${SHA_SHORT}" >> $GITHUB_OUTPUT
+          GIT_TAG=$(git describe --exact-match --tags 2>/dev/null || echo "")
+          echo "git_tag=${GIT_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build and push arm64 images
+        env:
+          SHA_SHORT: ${{ steps.meta.outputs.sha_short }}
+          GIT_TAG: ${{ steps.meta.outputs.git_tag }}
+        run: |
+          for entry in $IMAGES; do
+            IFS=':' read -r NAME CONTEXT DOCKERFILE <<< "$entry"
+            IMAGE="mniedermaier1337/${NAME}"
+
+            TAG_ARGS="-t ${IMAGE}:${SHA_SHORT}-arm64 -t ${IMAGE}:latest-arm64"
+            if [ -n "$GIT_TAG" ]; then
+              VERSION_TAG=${GIT_TAG#v}
+              TAG_ARGS="${TAG_ARGS} -t ${IMAGE}:${VERSION_TAG}-arm64"
+            fi
+
+            echo "::group::Building ${NAME} (arm64)"
+            docker buildx build \
+              --platform linux/arm64 \
+              ${TAG_ARGS} \
+              --push \
+              -f ${DOCKERFILE} \
+              ${CONTEXT}
+            echo "::endgroup::"
+          done
+
+  # ==== Create multi-arch manifests ====
+  create-manifests:
+    name: Create multi-arch manifests
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract version metadata
+        id: meta
+        run: |
+          SHA_SHORT=$(git rev-parse --short HEAD)
+          echo "sha_short=${SHA_SHORT}" >> $GITHUB_OUTPUT
+          GIT_TAG=$(git describe --exact-match --tags 2>/dev/null || echo "")
+          echo "git_tag=${GIT_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Create and push multi-arch manifests
+        env:
+          SHA_SHORT: ${{ steps.meta.outputs.sha_short }}
+          GIT_TAG: ${{ steps.meta.outputs.git_tag }}
+        run: |
+          for entry in $IMAGES; do
+            IFS=':' read -r NAME CONTEXT DOCKERFILE <<< "$entry"
+            IMAGE="mniedermaier1337/${NAME}"
+
+            echo "::group::Creating manifest for ${NAME}"
+
+            # Create 'latest' manifest
+            docker buildx imagetools create \
+              -t ${IMAGE}:latest \
+              ${IMAGE}:latest-amd64 \
+              ${IMAGE}:latest-arm64
+
+            # Create SHA-tagged manifest
+            docker buildx imagetools create \
+              -t ${IMAGE}:${SHA_SHORT} \
+              ${IMAGE}:${SHA_SHORT}-amd64 \
+              ${IMAGE}:${SHA_SHORT}-arm64
+
+            # Create version-tagged manifest if this is a release
+            if [ -n "$GIT_TAG" ]; then
+              VERSION_TAG=${GIT_TAG#v}
+              docker buildx imagetools create \
+                -t ${IMAGE}:${VERSION_TAG} \
+                ${IMAGE}:${VERSION_TAG}-amd64 \
+                ${IMAGE}:${VERSION_TAG}-arm64
+            fi
+
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
## Summary
- Fix arm64 build failure (libc-bin SIGSEGV under QEMU emulation)
- Replace single QEMU-emulated multi-arch job with parallel native builds
- Both architectures build simultaneously on native hardware

## Architecture
```
build-amd64 (ubuntu-latest)  ──┐
                                ├──> create-manifests (merge into multi-arch tags)
build-arm64 (ubuntu-24.04-arm) ┘
```

## Changes
- `build-amd64`: runs on x86 runner, pushes `*-amd64` tags
- `build-arm64`: runs on native ARM runner, pushes `*-arm64` tags
- `create-manifests`: merges platform images into `latest`, SHA, and version tags via `docker buildx imagetools create`

## Test plan
- [ ] Verify both build jobs start on correct runner types
- [ ] Verify all 10 images build successfully on both architectures
- [ ] Verify multi-arch manifests are created with both platforms
- [ ] Verify `docker pull` on amd64 and arm64 hosts pulls correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)