### PR TITLE
Fix landing webshell nmap scanning: NSE engine + scans that survive navigation

### DIFF
--- a/software/landing/Dockerfile
+++ b/software/landing/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     libpcap-dev \
     tcpdump \
     nmap \
+    nmap-scripts \
     iproute2 \
     iputils \
     net-tools \

--- a/software/landing/app.py
+++ b/software/landing/app.py
@@ -144,43 +144,173 @@ def webshell_page():
     logger.info('Rendering webshell page')
     return render_template('webshell.html')
 
+# ---------- WebShell background job registry ----------
+# Commands run as tracked background jobs so long-running scans (e.g. a full
+# `nmap -sV`) survive the user navigating away from the webshell page and back.
+# The page starts a job, then polls for incremental output by job id.
+import threading  # noqa: E402
+import uuid  # noqa: E402
+import time  # noqa: E402
+import signal  # noqa: E402
+import subprocess  # noqa: E402
+
+_WEBSHELL_JOB_TTL = 30 * 60          # keep finished jobs 30 min for late reattach
+_WEBSHELL_MAX_JOBS = 40              # cap registry size
+_WEBSHELL_MAX_OUTPUT = 512 * 1024    # cap captured output per job (bytes) -> ~0.5MB
+
+_webshell_jobs = {}
+_webshell_jobs_lock = threading.Lock()
+
+
+class WebShellJob:
+    """A single background command execution with incrementally captured output."""
+
+    def __init__(self, command):
+        self.id = uuid.uuid4().hex[:12]
+        self.command = command
+        self.output = ''
+        self.truncated = False
+        self.running = True
+        self.exit_code = None
+        self.proc = None
+        self.started_at = time.time()
+        self.finished_at = None
+        self.lock = threading.Lock()
+
+    def append(self, text):
+        with self.lock:
+            if self.truncated:
+                return
+            room = _WEBSHELL_MAX_OUTPUT - len(self.output)
+            if len(text) > room:
+                self.output += text[:room] + '\n[output truncated]\n'
+                self.truncated = True
+            else:
+                self.output += text
+
+
+def _run_webshell_job(job):
+    """Run the job's command, streaming combined stdout/stderr into its buffer."""
+    try:
+        # Intentional: webshell provides command execution for CTF training.
+        # start_new_session lets us signal the whole process group on kill.
+        proc = subprocess.Popen(
+            job.command,  # nosec - intentional command execution for CTF webshell
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            cwd=os.path.expanduser('~'),
+            start_new_session=True,
+        )
+        job.proc = proc
+        for line in iter(proc.stdout.readline, ''):
+            job.append(line)
+        proc.stdout.close()
+        proc.wait()
+        exit_code = proc.returncode
+    except Exception as e:
+        logger.error(f'Error running webshell job: {e}', exc_info=True)
+        job.append(f'\n[error] {e}\n')
+        exit_code = -1
+    finally:
+        with job.lock:
+            job.exit_code = exit_code
+            job.running = False
+            job.finished_at = time.time()
+
+
+def _prune_webshell_jobs():
+    """Drop expired finished jobs and cap the registry size."""
+    now = time.time()
+    with _webshell_jobs_lock:
+        for jid in [j.id for j in _webshell_jobs.values()
+                    if not j.running and j.finished_at
+                    and now - j.finished_at > _WEBSHELL_JOB_TTL]:
+            _webshell_jobs.pop(jid, None)
+        if len(_webshell_jobs) > _WEBSHELL_MAX_JOBS:
+            finished = sorted(
+                [j for j in _webshell_jobs.values() if not j.running],
+                key=lambda j: j.finished_at or 0)
+            for j in finished[:len(_webshell_jobs) - _WEBSHELL_MAX_JOBS]:
+                _webshell_jobs.pop(j.id, None)
+
+
 @app.route('/api/webshell/execute', methods=['POST'])
 def execute_command():
-    """Execute a shell command and return the output"""
-    import subprocess
-    data = request.get_json()
-    command = data.get('command', '').strip()
+    """Start a shell command as a background job and return its job id."""
+    data = request.get_json(silent=True) or {}
+    command = (data.get('command') or '').strip()
 
     if not command:
         return jsonify({'success': False, 'output': 'No command provided'}), 400
 
-    logger.info(f'Executing webshell command: {command}')
+    logger.info(f'Starting webshell command: {command}')
+    _prune_webshell_jobs()
 
-    try:
-        # Intentional: webshell provides command execution for CTF training
-        result = subprocess.run(
-            command,  # nosec - intentional command execution for CTF webshell
-            shell=True,
-            capture_output=True,
-            text=True,
-            cwd=os.path.expanduser('~')
-        )
+    job = WebShellJob(command)
+    with _webshell_jobs_lock:
+        _webshell_jobs[job.id] = job
+    threading.Thread(target=_run_webshell_job, args=(job,), daemon=True).start()
 
-        output = result.stdout
-        if result.stderr:
-            output += '\n' + result.stderr
+    return jsonify({'success': True, 'job_id': job.id, 'command': command})
 
+
+@app.route('/api/webshell/jobs', methods=['GET'])
+def list_webshell_jobs():
+    """List known jobs so a returning page can reattach to a running scan."""
+    _prune_webshell_jobs()
+    with _webshell_jobs_lock:
+        jobs = sorted(_webshell_jobs.values(), key=lambda j: j.started_at)
+        payload = [{
+            'job_id': j.id,
+            'command': j.command,
+            'running': j.running,
+            'exit_code': j.exit_code,
+            'started_at': j.started_at,
+        } for j in jobs]
+    return jsonify({'success': True, 'jobs': payload})
+
+
+@app.route('/api/webshell/jobs/<job_id>', methods=['GET'])
+def get_webshell_job(job_id):
+    """Return incremental output for a job from the given byte offset."""
+    offset = request.args.get('offset', default=0, type=int) or 0
+    with _webshell_jobs_lock:
+        job = _webshell_jobs.get(job_id)
+    if job is None:
+        return jsonify({'success': False, 'error': 'unknown job'}), 404
+
+    with job.lock:
+        if offset < 0 or offset > len(job.output):
+            offset = 0
+        chunk = job.output[offset:]
         return jsonify({
             'success': True,
-            'output': output,
-            'exit_code': result.returncode
+            'job_id': job.id,
+            'command': job.command,
+            'chunk': chunk,
+            'offset': offset + len(chunk),
+            'running': job.running,
+            'exit_code': job.exit_code,
         })
-    except Exception as e:
-        logger.error(f'Error executing command: {e}', exc_info=True)
-        return jsonify({
-            'success': False,
-            'output': 'Internal server error'
-        }), 500
+
+
+@app.route('/api/webshell/jobs/<job_id>/kill', methods=['POST'])
+def kill_webshell_job(job_id):
+    """Terminate a running job's process group."""
+    with _webshell_jobs_lock:
+        job = _webshell_jobs.get(job_id)
+    if job is None:
+        return jsonify({'success': False, 'error': 'unknown job'}), 404
+
+    if job.running and job.proc is not None:
+        try:
+            os.killpg(os.getpgid(job.proc.pid), signal.SIGTERM)
+        except Exception as e:
+            logger.warning(f'Failed to kill webshell job {job_id}: {e}')
+    return jsonify({'success': True})
 
 # ========== CTF ROUTES ==========
 

--- a/software/landing/templates/webshell.html
+++ b/software/landing/templates/webshell.html
@@ -269,6 +269,7 @@
                 autocomplete="off"
             >
             <button class="execute-button" id="execute-btn" onclick="executeCommand()">Execute</button>
+            <button class="clear-button" id="stop-btn" onclick="stopCommand()" disabled>Stop</button>
             <button class="clear-button" onclick="clearTerminal()">Clear</button>
         </div>
     </div>
@@ -277,11 +278,36 @@
         const terminalOutput = document.getElementById('terminal-output');
         const commandInput = document.getElementById('command-input');
         const executeBtn = document.getElementById('execute-btn');
+        const stopBtn = document.getElementById('stop-btn');
         let commandHistory = [];
         let historyIndex = -1;
 
-        // Focus input on load
-        commandInput.focus();
+        // Commands run as server-side background jobs; the terminal log and the
+        // active job are mirrored to sessionStorage so a running scan survives
+        // navigating away from this page and coming back within the same tab.
+        const LOG_KEY = 'cybics_webshell_log';
+        const ACTIVE_KEY = 'cybics_webshell_active';
+        const POLL_MS = 1000;
+        let pollTimer = null;
+
+        function persistLog() {
+            try { sessionStorage.setItem(LOG_KEY, terminalOutput.innerHTML); } catch (e) {}
+        }
+        function restoreLog() {
+            try {
+                const saved = sessionStorage.getItem(LOG_KEY);
+                if (saved !== null) terminalOutput.innerHTML = saved;
+            } catch (e) {}
+        }
+        function setActiveJob(job) {
+            try { sessionStorage.setItem(ACTIVE_KEY, JSON.stringify(job)); } catch (e) {}
+        }
+        function clearActiveJob() {
+            try { sessionStorage.removeItem(ACTIVE_KEY); } catch (e) {}
+        }
+        function getActiveJob() {
+            try { return JSON.parse(sessionStorage.getItem(ACTIVE_KEY) || 'null'); } catch (e) { return null; }
+        }
 
         // Handle Enter key
         commandInput.addEventListener('keydown', function(e) {
@@ -319,6 +345,7 @@
             line.innerHTML = content;
             terminalOutput.appendChild(line);
             terminalOutput.scrollTop = terminalOutput.scrollHeight;
+            persistLog();
         }
 
         function clearTerminal() {
@@ -327,11 +354,44 @@
                     <span class="terminal-output-text">Terminal cleared.</span>
                 </div>
             `;
+            persistLog();
+        }
+
+        // Create the streaming output element for a job. Tagged with data-job so
+        // it can be found again after the log is restored from sessionStorage.
+        function createOutputElement(jobId) {
+            const line = document.createElement('div');
+            line.className = 'terminal-line';
+            const span = document.createElement('span');
+            span.className = 'terminal-output-text';
+            span.setAttribute('data-job', jobId);
+            line.appendChild(span);
+            terminalOutput.appendChild(line);
+            return span;
+        }
+
+        function appendChunk(outEl, text) {
+            outEl.textContent += text;
+            terminalOutput.scrollTop = terminalOutput.scrollHeight;
+            persistLog();
+        }
+
+        function setRunning(running) {
+            executeBtn.disabled = running;
+            stopBtn.disabled = !running;
+            executeBtn.innerHTML = running ? 'Running<span class="loading"></span>' : 'Execute';
+        }
+
+        function finishRun() {
+            if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+            clearActiveJob();
+            setRunning(false);
+            commandInput.focus();
         }
 
         async function executeCommand() {
             const command = commandInput.value.trim();
-            if (!command) {
+            if (!command || executeBtn.disabled) {
                 return;
             }
 
@@ -342,42 +402,85 @@
             // Display command
             addTerminalLine(`<span class="terminal-prompt">root@cybics:~$</span> <span class="terminal-command">${escapeHtml(command)}</span>`);
 
-            // Clear input and disable button
             commandInput.value = '';
-            executeBtn.disabled = true;
-            executeBtn.innerHTML = 'Executing<span class="loading"></span>';
+            setRunning(true);
 
             try {
                 const response = await fetch('/api/webshell/execute', {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
+                    headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ command: command })
                 });
-
                 const data = await response.json();
 
-                if (data.success) {
-                    const output = data.output || '(no output)';
-                    addTerminalLine(`<span class="terminal-output-text">${escapeHtml(output)}</span>`);
-                    if (data.exit_code !== 0) {
-                        addTerminalLine(`<span class="terminal-error">Exit code: ${data.exit_code}</span>`);
-                    }
-                } else {
-                    addTerminalLine(`<span class="terminal-error">Error: ${escapeHtml(data.output)}</span>`);
+                if (!data.success || !data.job_id) {
+                    addTerminalLine(`<span class="terminal-error">Error: ${escapeHtml(data.output || 'could not start command')}</span>`);
+                    addTerminalLine('<span class="terminal-output-text">---</span>');
+                    finishRun();
+                    return;
                 }
+
+                const outEl = createOutputElement(data.job_id);
+                setActiveJob({ job_id: data.job_id, offset: 0 });
+                persistLog();
+                pollJob(data.job_id, outEl, 0);
             } catch (error) {
                 addTerminalLine(`<span class="terminal-error">Request failed: ${escapeHtml(error.message)}</span>`);
+                addTerminalLine('<span class="terminal-output-text">---</span>');
+                finishRun();
+            }
+        }
+
+        // Poll a background job for incremental output until it finishes.
+        async function pollJob(jobId, outEl, offset) {
+            let data;
+            try {
+                const r = await fetch(`/api/webshell/jobs/${jobId}?offset=${offset}`);
+                if (r.status === 404) {
+                    appendChunk(outEl, '\n[job is no longer available]\n');
+                    addTerminalLine('<span class="terminal-output-text">---</span>');
+                    finishRun();
+                    return;
+                }
+                data = await r.json();
+            } catch (error) {
+                // Transient error (e.g. mid-navigation); retry shortly.
+                pollTimer = setTimeout(() => pollJob(jobId, outEl, offset), POLL_MS);
+                return;
             }
 
-            // Re-enable button
-            executeBtn.disabled = false;
-            executeBtn.textContent = 'Execute';
-            commandInput.focus();
+            if (data.chunk) appendChunk(outEl, data.chunk);
+            offset = data.offset;
+            setActiveJob({ job_id: jobId, offset: offset });
 
-            // Add separator
-            addTerminalLine('<span class="terminal-output-text">---</span>');
+            if (data.running) {
+                pollTimer = setTimeout(() => pollJob(jobId, outEl, offset), POLL_MS);
+            } else {
+                if (data.exit_code !== 0 && data.exit_code !== null) {
+                    addTerminalLine(`<span class="terminal-error">Exit code: ${data.exit_code}</span>`);
+                }
+                addTerminalLine('<span class="terminal-output-text">---</span>');
+                finishRun();
+            }
+        }
+
+        async function stopCommand() {
+            const active = getActiveJob();
+            if (!active || !active.job_id) return;
+            stopBtn.disabled = true;
+            try {
+                await fetch(`/api/webshell/jobs/${active.job_id}/kill`, { method: 'POST' });
+            } catch (e) {}
+        }
+
+        // Reattach to an in-progress job after the page (re)loads.
+        function resumeActiveJob() {
+            const active = getActiveJob();
+            if (!active || !active.job_id) return;
+            let outEl = terminalOutput.querySelector(`[data-job="${active.job_id}"]`);
+            if (!outEl) outEl = createOutputElement(active.job_id);
+            setRunning(true);
+            pollJob(active.job_id, outEl, active.offset || 0);
         }
 
         function escapeHtml(text) {
@@ -391,6 +494,11 @@
             terminalOutput.scrollTop = terminalOutput.scrollHeight;
         });
         observer.observe(terminalOutput, { childList: true, subtree: true });
+
+        // Restore previous session output and reattach to any running job.
+        restoreLog();
+        resumeActiveJob();
+        commandInput.focus();
     </script>
 </body>
 </html>


### PR DESCRIPTION
Two fixes for the landing-page webshell used in the scanning CTF challenges. Split out of #196 so it can be reviewed and merged independently.

## 1. Fix nmap NSE engine (`nmap-scripts`)
The Alpine `nmap` package ships only the binary; the NSE engine files (`nse_main.lua` and `scripts/`) live in the separate `nmap-scripts` package. Without it, `nmap -sV` and any `--script` scan fail in the webshell with `could not locate nse_main.lua`. Installs `nmap-scripts` in the landing Dockerfile.

## 2. Run webshell commands as background jobs
The webshell ran each command as a single blocking request whose output lived only in the page DOM, so navigating away aborted the request and discarded a running scan (e.g. a multi-minute `nmap -sV`).

Commands now run as tracked server-side jobs:
- `POST /api/webshell/execute` starts a job and returns a `job_id`
- `GET /api/webshell/jobs/<id>?offset=N` streams incremental output
- `GET /api/webshell/jobs` lists jobs for reattach
- `POST /api/webshell/jobs/<id>/kill` terminates the process group

The page polls by offset and mirrors the terminal log and active job to `sessionStorage`, restoring output and reattaching to a running job on load. Output is capped per job and finished jobs are pruned to respect the container memory limit. Adds a Stop button.

## Verification
Exercised against the running landing container: immediate `job_id`, incremental polling with no duplication, jobs completing independently of the caller, kill via SIGTERM (exit `-15`), 404 for unknown jobs, and `nmap -sV -p80 localhost` now returning cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)