### PR TITLE
Bump pip group across 3 directories, with pytest 9 plugin compatibility

### DIFF
--- a/software/hwio-virtual/requirements.txt
+++ b/software/hwio-virtual/requirements.txt
@@ -1,2 +1,2 @@
 pymodbus==3.11.3
-nicegui==3.9.0
+nicegui==3.10.0

--- a/software/landing/requirements.txt
+++ b/software/landing/requirements.txt
@@ -6,4 +6,4 @@ requests-unixsocket==0.4.1
 netifaces2==0.0.22
 scapy==2.7.0rc1
 pymodbus==3.5.4
-python-dotenv==1.0.0
+python-dotenv==1.2.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
-pytest==8.3.4
+pytest==9.0.3
 pytest-cov==6.0.0
 pytest-asyncio==0.25.0
 pymodbus==3.11.3
 asyncua==1.1.8
 requests==2.33.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest==9.0.3
-pytest-cov==6.0.0
-pytest-asyncio==0.25.0
+pytest-cov==7.1.0
+pytest-asyncio==1.4.0
 pymodbus==3.11.3
 asyncua==1.1.8
 requests==2.33.0


### PR DESCRIPTION
Supersedes #188.

#188 bumped `pytest` 8.3.4 → 9.0.3 but left `pytest-asyncio` at 0.25.0, which pins `pytest<9`. The resulting constraint set is unsatisfiable — `pip install -r tests/requirements.txt` fails outright:

```
ERROR: Cannot install -r tests/requirements.txt (line 2), -r tests/requirements.txt (line 3)
and pytest==9.0.3 because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

That is why all five test jobs on #188 failed. (Its run logs have since expired to HTTP 410, so the cause was no longer visible from the checks UI.)

This PR keeps Dependabot's original commit and adds the plugin bumps needed to make the set installable:

- `pytest-asyncio` 0.25.0 → 1.4.0
- `pytest-cov` 6.0.0 → 7.1.0

Unchanged from #188: `nicegui` 3.9.0 → 3.10.0, `python-dotenv` 1.0.0/1.0.1 → 1.2.2, `pytest` 8.3.4 → 9.0.3.

## Verification

- `pip install -r tests/requirements.txt` resolves cleanly.
- All 41 tests collect under pytest 9 with pytest-asyncio 1.4.0 — no async-mode errors or warnings.
- The service-independent tests pass; the rest need the running stack and are left to CI.
- `nicegui` 3.10.0 imports, and every `ui.*` API used by `hwio-virtual/hardwareAbstraction.py` still exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3