### PR TITLE
Use a read-only Docker Hub token for devContainer CI

### DIFF
--- a/.github/workflows/devContainer.yml
+++ b/.github/workflows/devContainer.yml
@@ -29,10 +29,12 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
-        # Skipped when no credentials are available (Dependabot / fork PRs).
-        # The images pulled here are public, so anonymous pulls still work;
-        # authentication only raises the Docker Hub rate limit.
-        if: env.DOCKERHUB_USERNAME != ''
+        # Never authenticate on pull requests: these jobs only need to PULL
+        # public images, so a push-capable credential has no business being in
+        # a job that executes pull request code. Dependabot and fork PRs cannot
+        # read secrets anyway, so the env check keeps push/schedule runs from
+        # failing if the secret is ever missing.
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -82,10 +84,12 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
-        # Skipped when no credentials are available (Dependabot / fork PRs).
-        # The images pulled here are public, so anonymous pulls still work;
-        # authentication only raises the Docker Hub rate limit.
-        if: env.DOCKERHUB_USERNAME != ''
+        # Never authenticate on pull requests: these jobs only need to PULL
+        # public images, so a push-capable credential has no business being in
+        # a job that executes pull request code. Dependabot and fork PRs cannot
+        # read secrets anyway, so the env check keeps push/schedule runs from
+        # failing if the secret is ever missing.
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -138,10 +142,12 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
-        # Skipped when no credentials are available (Dependabot / fork PRs).
-        # The images pulled here are public, so anonymous pulls still work;
-        # authentication only raises the Docker Hub rate limit.
-        if: env.DOCKERHUB_USERNAME != ''
+        # Never authenticate on pull requests: these jobs only need to PULL
+        # public images, so a push-capable credential has no business being in
+        # a job that executes pull request code. Dependabot and fork PRs cannot
+        # read secrets anyway, so the env check keeps push/schedule runs from
+        # failing if the secret is ever missing.
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -182,10 +188,12 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
-        # Skipped when no credentials are available (Dependabot / fork PRs).
-        # The images pulled here are public, so anonymous pulls still work;
-        # authentication only raises the Docker Hub rate limit.
-        if: env.DOCKERHUB_USERNAME != ''
+        # Never authenticate on pull requests: these jobs only need to PULL
+        # public images, so a push-capable credential has no business being in
+        # a job that executes pull request code. Dependabot and fork PRs cannot
+        # read secrets anyway, so the env check keeps push/schedule runs from
+        # failing if the secret is ever missing.
+        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/devContainer.yml
+++ b/.github/workflows/devContainer.yml
@@ -13,6 +13,11 @@ jobs:
     name: Run devcontainer test raspberry on Ubuntu 22.04
     runs-on: ubuntu-22.04
 
+    env:
+      # Exposed so the login step below can detect whether credentials exist.
+      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
     steps:
       - name: Free up disk space
         run: |
@@ -24,6 +29,10 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
+        # Skipped when no credentials are available (Dependabot / fork PRs).
+        # The images pulled here are public, so anonymous pulls still work;
+        # authentication only raises the Docker Hub rate limit.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -57,6 +66,11 @@ jobs:
     name: Run devcontainer test raspberry on Ubuntu 24.04
     runs-on: ubuntu-24.04
 
+    env:
+      # Exposed so the login step below can detect whether credentials exist.
+      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
     steps:
       - name: Free up disk space
         run: |
@@ -68,6 +82,10 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
+        # Skipped when no credentials are available (Dependabot / fork PRs).
+        # The images pulled here are public, so anonymous pulls still work;
+        # authentication only raises the Docker Hub rate limit.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -104,6 +122,11 @@ jobs:
     name: Run devcontainer test stm32
     runs-on: ubuntu-latest
 
+    env:
+      # Exposed so the login step below can detect whether credentials exist.
+      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
     steps:
       - name: Free up disk space
         run: |
@@ -115,6 +138,10 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
+        # Skipped when no credentials are available (Dependabot / fork PRs).
+        # The images pulled here are public, so anonymous pulls still work;
+        # authentication only raises the Docker Hub rate limit.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -139,6 +166,11 @@ jobs:
     name: Run devcontainer test virtual
     runs-on: ubuntu-latest
 
+    env:
+      # Exposed so the login step below can detect whether credentials exist.
+      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
     steps:
       - name: Free up disk space
         run: |
@@ -150,6 +182,10 @@ jobs:
           df -h
 
       - name: Login to Docker Hub
+        # Skipped when no credentials are available (Dependabot / fork PRs).
+        # The images pulled here are public, so anonymous pulls still work;
+        # authentication only raises the Docker Hub rate limit.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/devContainer.yml
+++ b/.github/workflows/devContainer.yml
@@ -15,8 +15,8 @@ jobs:
 
     env:
       # Exposed so the login step below can detect whether credentials exist.
-      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # Empty for fork PRs, which cannot read repository secrets at all.
+      DOCKERHUB_RO_USERNAME: ${{ secrets.DOCKERHUB_RO_USERNAME }}
 
     steps:
       - name: Free up disk space
@@ -28,17 +28,18 @@ jobs:
           sudo docker system prune -af
           df -h
 
-      - name: Login to Docker Hub
-        # Never authenticate on pull requests: these jobs only need to PULL
-        # public images, so a push-capable credential has no business being in
-        # a job that executes pull request code. Dependabot and fork PRs cannot
-        # read secrets anyway, so the env check keeps push/schedule runs from
-        # failing if the secret is ever missing.
-        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
+      - name: Login to Docker Hub (read-only)
+        # These jobs only PULL images, so they use a read-only token. The
+        # push-capable DOCKERHUB_TOKEN stays exclusively in pushDockerRepos.yml
+        # and is never present in a job that executes pull request code.
+        # Authenticating raises the pull rate limit from 100/6h (anonymous) to
+        # 200/h. Fork PRs cannot read secrets, so the guard lets them fall back
+        # to anonymous pulls instead of failing the job.
+        if: env.DOCKERHUB_RO_USERNAME != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_RO_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_RO_TOKEN }}
 
       - name: Check out code
         uses: actions/checkout@v6
@@ -70,8 +71,8 @@ jobs:
 
     env:
       # Exposed so the login step below can detect whether credentials exist.
-      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # Empty for fork PRs, which cannot read repository secrets at all.
+      DOCKERHUB_RO_USERNAME: ${{ secrets.DOCKERHUB_RO_USERNAME }}
 
     steps:
       - name: Free up disk space
@@ -83,17 +84,18 @@ jobs:
           sudo docker system prune -af
           df -h
 
-      - name: Login to Docker Hub
-        # Never authenticate on pull requests: these jobs only need to PULL
-        # public images, so a push-capable credential has no business being in
-        # a job that executes pull request code. Dependabot and fork PRs cannot
-        # read secrets anyway, so the env check keeps push/schedule runs from
-        # failing if the secret is ever missing.
-        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
+      - name: Login to Docker Hub (read-only)
+        # These jobs only PULL images, so they use a read-only token. The
+        # push-capable DOCKERHUB_TOKEN stays exclusively in pushDockerRepos.yml
+        # and is never present in a job that executes pull request code.
+        # Authenticating raises the pull rate limit from 100/6h (anonymous) to
+        # 200/h. Fork PRs cannot read secrets, so the guard lets them fall back
+        # to anonymous pulls instead of failing the job.
+        if: env.DOCKERHUB_RO_USERNAME != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_RO_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_RO_TOKEN }}
 
       - name: Check out code
         uses: actions/checkout@v6
@@ -128,8 +130,8 @@ jobs:
 
     env:
       # Exposed so the login step below can detect whether credentials exist.
-      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # Empty for fork PRs, which cannot read repository secrets at all.
+      DOCKERHUB_RO_USERNAME: ${{ secrets.DOCKERHUB_RO_USERNAME }}
 
     steps:
       - name: Free up disk space
@@ -141,17 +143,18 @@ jobs:
           sudo docker system prune -af
           df -h
 
-      - name: Login to Docker Hub
-        # Never authenticate on pull requests: these jobs only need to PULL
-        # public images, so a push-capable credential has no business being in
-        # a job that executes pull request code. Dependabot and fork PRs cannot
-        # read secrets anyway, so the env check keeps push/schedule runs from
-        # failing if the secret is ever missing.
-        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
+      - name: Login to Docker Hub (read-only)
+        # These jobs only PULL images, so they use a read-only token. The
+        # push-capable DOCKERHUB_TOKEN stays exclusively in pushDockerRepos.yml
+        # and is never present in a job that executes pull request code.
+        # Authenticating raises the pull rate limit from 100/6h (anonymous) to
+        # 200/h. Fork PRs cannot read secrets, so the guard lets them fall back
+        # to anonymous pulls instead of failing the job.
+        if: env.DOCKERHUB_RO_USERNAME != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_RO_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_RO_TOKEN }}
 
       - name: Check out code
         uses: actions/checkout@v6
@@ -174,8 +177,8 @@ jobs:
 
     env:
       # Exposed so the login step below can detect whether credentials exist.
-      # Empty for Dependabot and fork PRs, which cannot read repository secrets.
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      # Empty for fork PRs, which cannot read repository secrets at all.
+      DOCKERHUB_RO_USERNAME: ${{ secrets.DOCKERHUB_RO_USERNAME }}
 
     steps:
       - name: Free up disk space
@@ -187,17 +190,18 @@ jobs:
           sudo docker system prune -af
           df -h
 
-      - name: Login to Docker Hub
-        # Never authenticate on pull requests: these jobs only need to PULL
-        # public images, so a push-capable credential has no business being in
-        # a job that executes pull request code. Dependabot and fork PRs cannot
-        # read secrets anyway, so the env check keeps push/schedule runs from
-        # failing if the secret is ever missing.
-        if: github.event_name != 'pull_request' && env.DOCKERHUB_USERNAME != ''
+      - name: Login to Docker Hub (read-only)
+        # These jobs only PULL images, so they use a read-only token. The
+        # push-capable DOCKERHUB_TOKEN stays exclusively in pushDockerRepos.yml
+        # and is never present in a job that executes pull request code.
+        # Authenticating raises the pull rate limit from 100/6h (anonymous) to
+        # 200/h. Fork PRs cannot read secrets, so the guard lets them fall back
+        # to anonymous pulls instead of failing the job.
+        if: env.DOCKERHUB_RO_USERNAME != ''
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_RO_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_RO_TOKEN }}
 
       - name: Check out code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Two problems, one root cause

**1. Dependabot and fork PRs always failed.** They cannot read Actions secrets, so `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` were empty and `docker/login-action` aborted at step 3 — before any code was checked out. Structural, not content-related:

| Workflow | Dependabot runs |
|---|---|
| devContainer | **14 failure / 0 success** — all at `Login to Docker Hub` |
| pytest | 10 success / 4 failure |
| CodeQL, flawFinder C, TruffleHog, zephyr CI | all success |

**2. PR runs carried a push-capable Docker Hub token for no reason.** These jobs only *pull*. A credential that can write to Docker Hub has no business in a job that executes pull request code.

## Fix: a dedicated read-only token

`devContainer.yml` now uses `DOCKERHUB_RO_USERNAME` / `DOCKERHUB_RO_TOKEN`. The push-capable `DOCKERHUB_TOKEN` stays **exclusively** in `pushDockerRepos.yml` — the only workflow that pushes, and it only runs on push to `main`.

```yaml
    env:
      DOCKERHUB_RO_USERNAME: ${{ secrets.DOCKERHUB_RO_USERNAME }}
    steps:
      - name: Login to Docker Hub (read-only)
        if: env.DOCKERHUB_RO_USERNAME != ''
```

Applied to all four jobs: `raspberry2204`, `raspberry2404`, `stm32`, `virtual`.

No PR run can now reach Docker Hub with write access — not because an `if` condition forbids it, but because the credential present simply *cannot* write. That holds for repository branches, Dependabot and forks alike.

The read-only credential is set in **both** secret stores (Actions + Dependabot), so Dependabot PRs authenticate and no longer die at the login step. Fork PRs get no secrets by design — the guard lets them fall back to anonymous pulls instead of killing the job.

Rate limit: **200/h authenticated** instead of 100/6h anonymous.

## Verified: PR tests push nothing to Docker Hub

- `pushDockerRepos.yml` (the only pushing workflow) triggers only on push to `main`.
- No `docker push`, no `build-push-action`, no `devcontainers/ci` `imageName` in any PR workflow.
- `software/build.sh` does use `--push`, but to `172.17.0.1:5050` — the local registry from `.devcontainer/raspberry/docker-compose.yml` (`5050:5000`), not Docker Hub.

## Security

- The trigger is `pull_request`, **not** `pull_request_target` (no workflow in the repo uses `pull_request_target`). Fork PRs get no secrets and a read-only `GITHUB_TOKEN` regardless.
- Fork PRs now actually run the devcontainer build instead of dying at step 3. That is not new exposure — `pytest`, `CodeQL`, `flawFinder`, `zephyr CI` and `TruffleHog` already run fork code. Build cache: PR runs write only to their own scope, so `main`'s cache cannot be poisoned from a PR branch.
- Worth pairing with **Settings → Actions → "Fork pull request workflows from outside collaborators"** set to require approval for *all* outside collaborators.

## Verification

`actionlint` clean. YAML parsed: all four jobs carry the env var and the guard, and `devContainer.yml` no longer references `secrets.DOCKERHUB_TOKEN`. The read-only token was tested against Docker Hub: login succeeded, pull succeeded, `ratelimit-limit: 200;w=3600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3
