### PR TITLE
Enable Dependabot version updates and close the nicegui advisory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+
+updates:
+  # Python dependencies across every requirements.txt in the repo.
+  # Grouped into a single weekly PR so the devcontainer jobs (~45 min each
+  # for the Raspberry targets) are not run once per bumped package.
+  - package-ecosystem: "pip"
+    directories:
+      - "/tests"
+      - "/software/*"
+      - "/training"
+      - "/training/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "pip"
+
+  # GitHub Actions used by the 8 workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/software/hwio-virtual/requirements.txt
+++ b/software/hwio-virtual/requirements.txt
@@ -1,2 +1,2 @@
 pymodbus==3.11.3
-nicegui==3.10.0
+nicegui==3.16.0


### PR DESCRIPTION
## Warum

Das Repo hatte **nie** eine `.github/dependabot.yml` — weder im Working Tree, noch auf `main`, noch irgendwo in der Git-Historie. Damit liefen bisher ausschließlich Dependabot-**Security**-Updates (`automated-security-fixes` ist aktiv). Routinemäßige **Version-Updates waren nie konfiguriert**. Deshalb waren die bisherigen Bot-PRs immer sicherheitsgetriebene, gruppierte Bumps wie #188.

## Was drin ist

**1. `.github/dependabot.yml`** — deckt alle **17** `requirements.txt`-Manifeste ab plus das `github-actions`-Ökosystem der 8 Workflows.

Bewusst **gruppiert und wöchentlich**: eine ungruppierte Config würde pro gebumptem Paket einen PR öffnen, und jeder kostet zwei Raspberry-devcontainer-Jobs à ~45 min.

**2. `nicegui` 3.10.0 → 3.16.0**

Der offene Dependabot-Advisory für nicegui (1 high, 1 moderate) ist erst **ab 3.12.0** gepatcht. Der Bump auf 3.10.0, der mit #200 gelandet ist, hat die Lücke also **nicht** geschlossen — das war beim Mergen nicht auf dem Schirm, #200 war als reiner pytest-Kompatibilitätsfix gedacht. 3.16.0 ist das aktuelle Release.

## Verifikation

- Config: YAML geparst; die Globs decken alle 17 Manifeste ab (per Skript gegen `git ls-tree` geprüft, 0 nicht abgedeckt).
- nicegui: Image gebaut, Container gestartet — UI auf `:8090` liefert HTTP 200, NiceGUI-Assets 200, Titel `CybICS VIRT` gerendert, keine Fehler in den Logs, `restarts=0`.
- Alle von `hardwareAbstraction.py` genutzten `ui.*`- und `app.*`-APIs existieren in 3.12.0 und 3.16.0 weiterhin.

## Bleibt offen

`chromadb` in `software/cybicsagent/requirements.txt` hat **1 critical + 1 high** ohne verfügbaren Patch. Das lässt sich nicht durch ein Update lösen und braucht eine eigene Bewertung, ob der verwundbare Pfad überhaupt erreichbar ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3