### PR TITLE
Bump python-dotenv and pytest (the safe half of #203)

### DIFF
--- a/software/landing/requirements.txt
+++ b/software/landing/requirements.txt
@@ -6,4 +6,4 @@ requests-unixsocket==0.4.1
 netifaces2==0.0.22
 scapy==2.7.0rc1
 pymodbus==3.5.4
-python-dotenv==1.2.2
+python-dotenv==1.2.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
-pytest==9.0.3
+pytest==9.1.1
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
 pymodbus==3.11.3
 asyncua==1.1.8
 requests==2.33.0
-python-dotenv==1.2.2
+python-dotenv==1.2.3


### PR DESCRIPTION
Takes the two harmless bumps from Dependabot's #203 and deliberately leaves out the two problematic ones.

## Taken

- `python-dotenv` 1.2.2 → 1.2.3 (`software/landing`, `tests`)
- `pytest` 9.0.3 → 9.1.1 (`tests`)

## Deliberately left out

**`nicegui` 3.10.0 → 3.12.0 would now be a downgrade.** `main` has carried 3.16.0 since #204, which also closes both nicegui advisories.

**`chromadb` 0.4.22 → 1.5.9 does not fix anything.** The two open advisories

| GHSA | Severity | Vulnerable range | first_patched |
|---|---|---|---|
| GHSA-36p7-vc44-83pf | **critical** | `>= 0.4.17, <= 1.5.9` | `null` |
| GHSA-2wm9-hf6c-p5cr | **high** | `>= 0.4.17, <= 1.5.9` | `null` |

**include** 1.5.9 — there is simply no patched version. The bump would be a 0.4 → 1.5 major jump with real breakage risk for `cybicsagent` and no security gain whatsoever. That needs its own assessment, not a routine bump.

## Verification

- `tests/requirements.txt` resolves cleanly; all 41 tests collect under pytest 9.1.1 with pytest-cov 7.1.0 and pytest-asyncio 1.4.0; the service-independent tests pass.
- `software/landing/requirements.txt` resolves with the new python-dotenv, and `load_dotenv`/`dotenv_values` are present.

Supersedes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3
