### PR TITLE
Alert on OPC-UA access from the bundled attack machine

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -58,14 +58,12 @@ jobs:
     - name: Install test dependencies
       run: pip install --no-cache-dir -r tests/requirements.txt
 
-    - name: Test connections
-      run: pytest tests/test_connections.py --verbose
-
-    - name: Test OPC UA authentication
-      run: pytest tests/test_opcua_auth.py --verbose
-
-    - name: Test training
-      run: pytest tests/test_training.py --verbose
+    # Run the whole suite rather than naming files one by one: a test file
+    # that is not listed here is silently never executed, which is how
+    # tests/test_plant_model_parity.py would have been added without ever
+    # running in CI.
+    - name: Run test suite
+      run: pytest tests/ --verbose
 
     - name: Stop containers
       if: always()

--- a/software/ids/rules.py
+++ b/software/ids/rules.py
@@ -38,7 +38,12 @@ KNOWN_SERVICES = {
     "172.18.0.100": "attack-machine",
 }
 
-# Modbus function codes considered dangerous (write operations)
+# Modbus function codes considered dangerous (write operations).
+# Note that the flood and unauthorised-write rules below only ever look at
+# these codes, so a *read* flood raises nothing regardless of its rate.  That
+# is deliberate -- reads are normal polling traffic here -- but it means the
+# detection modules must not be described as catching Modbus flooding in
+# general.
 MODBUS_WRITE_FUNCTIONS = {0x05, 0x06, 0x0F, 0x10}
 MODBUS_DIAGNOSTIC = {0x08, 0x2B}
 
@@ -46,6 +51,11 @@ MODBUS_DIAGNOSTIC = {0x08, 0x2B}
 _MODBUS_WRITERS = frozenset(("hwio", "fuxa", "openplc"))
 # Services allowed to do Modbus writes without triggering unauth rule
 _MODBUS_AUTH_WRITERS = frozenset(("hwio", "fuxa"))
+# Services that legitimately originate OPC-UA sessions.  Deliberately narrower
+# than KNOWN_SERVICES: the bundled attack machine is a known service too, and
+# exempting all of KNOWN_SERVICES meant OPC-UA activity from the attack box
+# never raised an alert -- the one host the exercise expects to be detected.
+_OPCUA_CLIENTS = frozenset(("hwio", "fuxa", "openplc", "opcua"))
 
 # Packet tuple indices (matches _parse_raw_packet output)
 _SRC_IP = 0
@@ -338,7 +348,7 @@ class RuleEngine:
     def _check_opcua(self, pkt, src_ip, alerts):
         if len(pkt[_PAYLOAD]) < 8:
             return
-        if src_ip not in KNOWN_SERVICES:
+        if KNOWN_SERVICES.get(src_ip) not in _OPCUA_CLIENTS:
             now = time.time()
             if self._should_alert("opcua_access", src_ip, now):
                 alerts.append({

--- a/tests/test_ids_rules.py
+++ b/tests/test_ids_rules.py
@@ -1,0 +1,77 @@
+"""Unit tests for the IDS rule engine (software/ids/rules.py).
+
+These exercise the rule logic directly against parsed packet tuples, so they
+need no running stack and no captured traffic.
+
+The OPC-UA cases exist because the rule used to exempt every host in
+KNOWN_SERVICES, which includes the bundled attack machine -- so the one host
+an exercise expects to be detected was the one host that never alerted.
+"""
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+IDS_DIR = os.path.join(ROOT, "software", "ids")
+
+if not os.path.exists(os.path.join(IDS_DIR, "rules.py")):
+    pytest.skip("software/ids/rules.py not present", allow_module_level=True)
+
+sys.path.insert(0, IDS_DIR)
+import rules  # noqa: E402
+
+
+ATTACK_MACHINE = "172.18.0.100"
+OPCUA_SERVER = "172.18.0.5"
+HWIO = "172.18.0.2"
+OUTSIDE = "172.18.0.1"
+
+
+def _opcua_packet(src_ip):
+    """A TCP packet to the OPC-UA port with a payload long enough to be checked.
+
+    Tuple layout matches _parse_raw_packet: src, dst, sport, dport, flags,
+    proto, payload, arp_op.
+    """
+    return (src_ip, OPCUA_SERVER, 51000, 4840, "PA", 6, b"HELF\x00\x00\x00\x00", None)
+
+
+def _rules_for(src_ip):
+    engine = rules.RuleEngine()
+    return engine.check_packet(_opcua_packet(src_ip))
+
+
+def _opcua_alerts(alerts):
+    return [a for a in alerts if a["rule"] == "opcua_access"]
+
+
+def test_opcua_access_from_attack_machine_alerts():
+    """The regression this fix is about: the attack box must be detected."""
+    assert _opcua_alerts(_rules_for(ATTACK_MACHINE)), (
+        "OPC-UA access from the bundled attack machine raised no alert"
+    )
+
+
+def test_opcua_access_from_unknown_host_alerts():
+    assert _opcua_alerts(_rules_for(OUTSIDE))
+
+
+def test_opcua_access_from_ot_client_is_silent():
+    """hwio legitimately speaks OPC-UA and must not be flagged."""
+    assert not _opcua_alerts(_rules_for(HWIO))
+
+
+def test_attack_machine_is_still_a_known_service():
+    """The fix must not work by removing the attack machine from the map --
+    other rules rely on resolving its name."""
+    assert rules.KNOWN_SERVICES.get(ATTACK_MACHINE) == "attack-machine"
+
+
+def test_opcua_clients_are_a_subset_of_known_services():
+    assert set(rules._OPCUA_CLIENTS) <= set(rules.KNOWN_SERVICES.values())
+
+
+def test_short_payload_is_ignored():
+    pkt = (ATTACK_MACHINE, OPCUA_SERVER, 51000, 4840, "PA", 6, b"HEL", None)
+    assert not _opcua_alerts(rules.RuleEngine().check_packet(pkt))


### PR DESCRIPTION
Fixes **point 2** and one of the minor points from #199.

## The bug

`_check_opcua` in `software/ids/rules.py` exempted **every** host in `KNOWN_SERVICES` — and the attack machine is in that map as `172.18.0.100`:

```python
if src_ip not in KNOWN_SERVICES:   # the attack machine is in here
```

So the one host an exercise expects to be detected was the only one that **never** alerted. A student running the `opcua` module from the bundled attack box sees no detection and reasonably concludes the protocol is unmonitored.

## Fix

Scope the exemption to the hosts that **legitimately** originate OPC-UA, exactly the way `_check_modbus` already does with `_MODBUS_AUTH_WRITERS`:

```python
_OPCUA_CLIENTS = frozenset(("hwio", "fuxa", "openplc", "opcua"))
...
if KNOWN_SERVICES.get(src_ip) not in _OPCUA_CLIENTS:
```

The attack machine stays in `KNOWN_SERVICES` — other rules resolve its name through that map — it simply no longer counts as an OPC-UA client.

**One decision for the maintainer:** `engineeringws` and `cybicsagent` now alert on OPC-UA as well. That follows the suggestion in the issue. If the engineering workstation is meant to speak OPC-UA, it belongs in `_OPCUA_CLIENTS`.

## First tests for the rule engine

`tests/test_ids_rules.py` — `rules.py` had **no** tests at all. These run against parsed packet tuples, so they need neither a running stack nor a capture.

Verified to bite: with the old line, `test_opcua_access_from_attack_machine_alerts` fails; with the new one all 6 pass. One test also ensures the fix does not "work" by removing the attack machine from `KNOWN_SERVICES`.

## Minor point from #199: Modbus flood misses read floods

The flood and unauthorised-write rules only inspect write function codes, so a read flood raises nothing at **any** rate. That is deliberate — reads are normal polling traffic here — but it was documented nowhere. Comment added at `MODBUS_WRITE_FUNCTIONS`.

## CI

`pytest.yml` invoked three test files by name; a file that is not listed is silently never executed, so the new test would have been dead on arrival. Switched to `pytest tests/`.

The wording is **identical** to the change on the #201 branch so the two merge cleanly whichever lands first.

## Not included

Point 3 of #199 (`cybics-nginx-proxy` unpublished) is moot on `main`: the service is not in `.devcontainer/virtual/docker-compose.yml` there at all. The minor point about `attack-machine/README.md` has also resolved itself — `medusa`, `arpspoof`, `ettercap` and `bettercap` are no longer listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3
