### PR TITLE
Add concurrency groups to stop CI runs piling up

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -9,6 +9,15 @@ on:
 env:
   ZEPHYR_SDK_VERSION: 0.17.4
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,15 @@ on:
   schedule:
     - cron: "0 3 * * 1"
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/devContainer.yml
+++ b/.github/workflows/devContainer.yml
@@ -8,6 +8,15 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   raspberry2204:
     name: Run devcontainer test raspberry on Ubuntu 22.04

--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -10,6 +10,15 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   flawfinder:
     name: Flawfinder

--- a/.github/workflows/kibotVerify.yml
+++ b/.github/workflows/kibotVerify.yml
@@ -18,6 +18,15 @@ env:
   dir: "hardware/pcb/"
   config: "hardware/pcb/kibot.yaml"
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 # checks
   ERC:

--- a/.github/workflows/pushDockerRepos.yml
+++ b/.github/workflows/pushDockerRepos.yml
@@ -17,6 +17,15 @@ env:
     cybicsagent:software/cybicsagent:software/cybicsagent/Dockerfile
     cybics-ids:software/ids:software/ids/Dockerfile
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ==== Build amd64 natively on x86 runner ====
   build-amd64:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,15 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  # One run per workflow per ref.  Pull request runs are cancelled when a new
+  # commit is pushed; runs on main are not -- every commit there should still
+  # be built.  GitHub keeps at most one running plus one pending run per group,
+  # so a burst of merges no longer piles up dozens of concurrent jobs (which
+  # is how runs started failing at startup).
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

A push to `main` starts about **18 jobs** across eight workflows, and **not one** workflow declared a `concurrency` group. Nothing was superseded when a newer commit arrived moments later.

Merging three PRs within nine minutes left **nine workflow runs in flight across three commits** — roughly fifty concurrent jobs. Runs then started coming back with `startup_failure`: they could not be started at all.

GitHub reports this as *"This run likely failed because of a workflow file issue"*, which sends the diagnosis in the wrong direction. The files were fine:

- `codeql.yml` is **identical** at `31af5c9` (success) and `b9b3246` (`startup_failure`), and neither merged PR touched it.
- `pushDockerRepos.yml` parses cleanly, and its run for `31af5c9` was executing normally at the same time.
- Every bumped action tag (`checkout@v7`, `login-action@v4`, `setup-buildx-action@v4`) resolves as a git ref.

## Fix

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Added to all eight workflows. GitHub then keeps at most **one running plus one pending** run per group and discards superseded pending runs, so a burst of merges converges on the tip instead of fanning out.

`cancel-in-progress` is deliberately limited to pull requests:

- **`main` is left alone** — every commit there should still be built, and cancelling `pushDockerRepos.yml` mid-run could interrupt an image push.
- **Pull requests are cancelled** on a new push. That is where most of the saving is: a single `devContainer` run is four jobs, two of them around 45 minutes.

## Verification

All eight files parse and each carries `group` and `cancel-in-progress`; `actionlint` reports only the shellcheck findings that pre-exist on `main`. Purely additive — 72 lines inserted, none removed.

## Limitation

This PR cannot demonstrate its own effect in CI: `concurrency` only takes hold when runs actually collide. Green checks show the workflows are still valid, nothing more. The real test is the next burst of merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3
