### PR TITLE
Fetch the Zephyr SDK by URL instead of through the GitHub API

### DIFF
--- a/.devcontainer/stm32/Dockerfile
+++ b/.devcontainer/stm32/Dockerfile
@@ -68,8 +68,30 @@ RUN west init -l app && \
 # Install Python requirements using west (recommended method)
 RUN west packages pip --install
 
-# Install Zephyr SDK using west (only ARM toolchain)
-RUN west sdk install -t arm-zephyr-eabi
+# Install the Zephyr SDK (ARM toolchain only).
+#
+# Fetched straight from the release URL instead of via 'west sdk install',
+# which queries the GitHub API unauthenticated.  Anonymous API calls are capped
+# at 60/hour per IP, and on shared CI runners that budget is regularly spent by
+# unrelated jobs: 17 of the last 100 nightly devContainer runs failed right
+# here with HTTP 403 "API rate limit exceeded", independently of our own
+# activity.  Release asset downloads do not count against that budget.
+#
+# The version is read from the Zephyr tree so it follows software/stm32/west.yml
+# rather than drifting; .github/workflows/buildTest.yml installs the same SDK
+# the same way.
+RUN set -eu; \
+    SDK_VERSION="$(cat /home/docker/zephyrproject/zephyr/SDK_VERSION)"; \
+    BASE="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${SDK_VERSION}"; \
+    cd /home/docker; \
+    wget -q "${BASE}/zephyr-sdk-${SDK_VERSION}_linux-x86_64_minimal.tar.xz"; \
+    tar xf "zephyr-sdk-${SDK_VERSION}_linux-x86_64_minimal.tar.xz"; \
+    rm "zephyr-sdk-${SDK_VERSION}_linux-x86_64_minimal.tar.xz"; \
+    cd "zephyr-sdk-${SDK_VERSION}"; \
+    wget -q "${BASE}/toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz"; \
+    tar xf toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz; \
+    rm toolchain_linux-x86_64_arm-zephyr-eabi.tar.xz; \
+    ./setup.sh -t arm-zephyr-eabi -h -c
 
 # Switch back to root for fixuid setup
 USER root


### PR DESCRIPTION
## Problem

`west sdk install` resolves the SDK release through the **GitHub API without authentication**. Anonymous API calls are capped at **60 per hour per IP**, and on shared CI runners that budget is regularly spent by unrelated jobs:

```
Exception: Failed to fetch: 403, {"message":"API rate limit exceeded for 172.182.253.34. ..."}
process "/bin/sh -c west sdk install -t arm-zephyr-eabi" did not complete successfully: exit code: 1
```

**This is not caused by our own CI volume**, which was my first assumption. It recurs on quiet scheduled nightly runs from fresh runners with different IPs:

| Nightly `devContainer` runs | Result |
|---|---|
| last 100 | **17 failure / 83 success** |
| recent failures | 13 Aug, 18 Aug, 20 Aug, 23 Aug, 27 Aug — all at this step |

A workflow that is red roughly one night in six stops being a signal.

## Fix

Download the release assets directly. Asset downloads are served from a different endpoint and **do not count against the API rate limit**, so no token and no build secret is required — which matters, because these images are published to Docker Hub and a secret passed as `ARG` would end up in the image layers.

The version is **read from `zephyr/SDK_VERSION`** in the workspace rather than hardcoded, so it follows `software/stm32/west.yml` automatically instead of drifting. Zephyr v4.3.0 currently pins SDK 0.17.4.

`.github/workflows/buildTest.yml` already installs the same SDK the same way, so this aligns the devcontainer with the workflow.

## Verification

Not left to CI — built and exercised locally:

- Image builds cleanly (exit 0).
- SDK lands in `/home/docker/zephyr-sdk-0.17.4/`, matching where `west sdk install` put it.
- `setup.sh -t arm-zephyr-eabi -h -c` registers it in the CMake package registry (`~/.cmake/packages/Zephyr-sdk`), which is how Zephyr locates it.
- `arm-zephyr-eabi-gcc (Zephyr SDK 0.17.4) 12.2.0` runs.
- `west build -b nucleo_g070rb` links `zephyr.elf` — 165/165 targets, FLASH 59.69%, RAM 89.63%.
- Tarballs are removed after extraction, so the layer carries no dead weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3