### PR TITLE
Make CI actually test: reconnect on Modbus, and stop skipping failures

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,8 +60,11 @@ jobs:
       run: docker-compose -f "docker-compose.yml" up -d --build
       working-directory: ./.devcontainer/virtual
 
-    - name: Wait for services
-      run: sleep 120s
+    # No fixed sleep: the suite's own readiness gate (tests/conftest.py) polls
+    # every required port and fails with the exact list of services that never
+    # came up. A short settle gives the containers a chance to bind first.
+    - name: Let containers settle
+      run: sleep 15s
       shell: bash
 
     - name: Install test dependencies

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,21 @@
+[pytest]
+testpaths = tests
+
+# Fail on an unregistered marker instead of silently ignoring it: a typo in
+# @pytest.mark.asyncio used to make the test vanish from the run.
+addopts = --strict-markers --strict-config -ra
+
+markers =
+    slow: takes appreciably longer than a second
+
+# pytest-asyncio 1.x: be explicit rather than relying on a default that has
+# changed between releases. strict means async tests need @pytest.mark.asyncio.
+asyncio_mode = strict
+asyncio_default_fixture_loop_scope = function
+
+# Surface warnings rather than hiding them, but do not fail the run on
+# third-party deprecations we cannot act on.
+filterwarnings =
+    default
+    ignore::DeprecationWarning:asyncua.*
+    ignore::DeprecationWarning:pymodbus.*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,109 @@
-"""Shared helpers for the CybICS test suite.
+"""Shared configuration and helpers for the CybICS test suite.
 
-Currently this exists for one reason: Modbus calls against the OpenPLC runtime
-have to survive the server closing the connection underneath them.
+Two things live here that the suite previously lacked:
+
+* one definition of where the stack is and how long to wait for it, instead of
+  three copies that had drifted to different timeouts;
+* a readiness gate, so "the service was not up yet" fails once, loudly, instead
+  of being absorbed by every individual test as a skip.
 """
+import os
+import socket
+import time
+
 import pytest
 from pymodbus.exceptions import ConnectionException, ModbusException
 
-# Host the stack under test is reachable on. Overridable so the suite can be
-# pointed at a real device instead of a local compose stack.
-import os
+# --------------------------------------------------------------------------
+# Where the stack under test lives
+# --------------------------------------------------------------------------
 
 SERVER_IP = os.getenv("TEST_SERVER_IP", "127.0.0.1")
-CONNECTION_TIMEOUT = 20
 
+# Connection timeout for protocol clients.  This used to be 20 in two files and
+# 10 in a third, for no stated reason.
+CONNECTION_TIMEOUT = 20
+READ_TIMEOUT = 10
+
+MODBUS_SERVER_PORT = 502
+OPCUA_SERVER_PORT = 4840
+# Port 102 is OpenPLC's own S7/ISO-TSAP surface, 1102 is the separate s7com
+# service. test_connections scans 102, so keep that name pointing there.
+S7_SERVER_PORT = 102
+S7COM_PORT = 1102
+OPENPLC_PORT = 8080
+FUXA_PORT = 1881
+HWIO_PORT = 8090
+
+OPCUA_SERVER_URL = f"opc.tcp://{SERVER_IP}:{OPCUA_SERVER_PORT}"
+
+# Services the suite needs, and how long to wait for each on start-up.  The
+# workflow starts the stack immediately before running the suite, so the first
+# test can otherwise race the containers.
+REQUIRED_SERVICES = {
+    "modbus (openplc)": MODBUS_SERVER_PORT,
+    "opcua": OPCUA_SERVER_PORT,
+    "s7 (openplc)": S7_SERVER_PORT,
+    "s7com": S7COM_PORT,
+    "openplc web": OPENPLC_PORT,
+    "fuxa": FUXA_PORT,
+    "hwio": HWIO_PORT,
+}
+
+STACK_READY_TIMEOUT = int(os.getenv("TEST_STACK_TIMEOUT", "180"))
+
+
+# --------------------------------------------------------------------------
+# Readiness
+# --------------------------------------------------------------------------
+
+def wait_for_port(host, port, timeout, interval=1.0):
+    """Poll a TCP port until it accepts a connection. Returns True if it did.
+
+    Polling beats sleeping: it returns as soon as the service is actually up
+    rather than after a fixed guess, and it reports honestly when the service
+    never arrives.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                return True
+        except OSError:
+            time.sleep(interval)
+    return False
+
+
+@pytest.fixture(scope="session")
+def stack_ready():
+    """Wait for the whole stack once, and say plainly which parts never came up.
+
+    Requested per module via `pytestmark = pytest.mark.usefixtures("stack_ready")`
+    rather than autouse, so the tests that need no stack at all -- the IDS rule
+    engine and the plant model parity checks -- still run when nothing is up.
+
+    Without this, a service that is slow or dead surfaces as a scatter of
+    skipped tests, which reads as success on a green tick.  Here it is a single
+    failure naming exactly what is missing.
+    """
+    missing = []
+    deadline = time.monotonic() + STACK_READY_TIMEOUT
+    for name, port in REQUIRED_SERVICES.items():
+        remaining = max(1, deadline - time.monotonic())
+        if not wait_for_port(SERVER_IP, port, remaining):
+            missing.append(f"{name} ({SERVER_IP}:{port})")
+    if missing:
+        pytest.fail(
+            "Stack did not become ready within "
+            f"{STACK_READY_TIMEOUT}s. Not reachable: " + ", ".join(missing) +
+            ". These tests describe a running CybICS stack; a service that is "
+            "down is a failure, not a reason to skip."
+        )
+
+
+# --------------------------------------------------------------------------
+# Modbus
+# --------------------------------------------------------------------------
 
 def modbus_call(client, operation, *args, **kwargs):
     """Run a Modbus operation, reconnecting once if the server hung up.
@@ -27,21 +118,20 @@ def modbus_call(client, operation, *args, **kwargs):
             client.connect()
 
     is_socket_open() reports what the local transport believes, and a FIN from
-    the peer does not change that. It still returns True after the server has
+    the peer does not change that.  It still returns True after the server has
     closed, so the reconnect never happens and the next call raises
     ConnectionException - which is how a tolerated server behaviour turned into
     a red build roughly one run in ten since June.
 
     Only actually using the socket reveals the state, so try the call, and on a
-    connection error reconnect and try once more. A genuinely unreachable
+    connection error reconnect and try once more.  A genuinely unreachable
     server still fails, because the retry fails too.
     """
     try:
         return operation(*args, **kwargs)
     except (ConnectionException, ModbusException):
         if not client.connect():
-            pytest.skip(
-                "Modbus server closed the connection and refused a reconnect - "
-                "the runtime is likely restarting"
+            raise AssertionError(
+                "Modbus server closed the connection and refused a reconnect"
             )
         return operation(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared helpers for the CybICS test suite.
+
+Currently this exists for one reason: Modbus calls against the OpenPLC runtime
+have to survive the server closing the connection underneath them.
+"""
+import pytest
+from pymodbus.exceptions import ConnectionException, ModbusException
+
+# Host the stack under test is reachable on. Overridable so the suite can be
+# pointed at a real device instead of a local compose stack.
+import os
+
+SERVER_IP = os.getenv("TEST_SERVER_IP", "127.0.0.1")
+CONNECTION_TIMEOUT = 20
+
+
+def modbus_call(client, operation, *args, **kwargs):
+    """Run a Modbus operation, reconnecting once if the server hung up.
+
+    The OpenPLC runtime drops established Modbus connections from time to time -
+    it closes every client when the PLC program (re)starts, which in a freshly
+    composed stack can land in the middle of a test.
+
+    The obvious guard does not work:
+
+        if not client.is_socket_open():
+            client.connect()
+
+    is_socket_open() reports what the local transport believes, and a FIN from
+    the peer does not change that. It still returns True after the server has
+    closed, so the reconnect never happens and the next call raises
+    ConnectionException - which is how a tolerated server behaviour turned into
+    a red build roughly one run in ten since June.
+
+    Only actually using the socket reveals the state, so try the call, and on a
+    connection error reconnect and try once more. A genuinely unreachable
+    server still fails, because the retry fails too.
+    """
+    try:
+        return operation(*args, **kwargs)
+    except (ConnectionException, ModbusException):
+        if not client.connect():
+            pytest.skip(
+                "Modbus server closed the connection and refused a reconnect - "
+                "the runtime is likely restarting"
+            )
+        return operation(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,15 +25,21 @@ SERVER_IP = os.getenv("TEST_SERVER_IP", "127.0.0.1")
 CONNECTION_TIMEOUT = 20
 READ_TIMEOUT = 10
 
-MODBUS_SERVER_PORT = 502
-OPCUA_SERVER_PORT = 4840
+def _port(name, default):
+    """Port of a service, overridable so the suite can run against a stack that
+    had to publish elsewhere -- a busy host port, or a real device."""
+    return int(os.getenv(f"TEST_{name}_PORT", default))
+
+
+MODBUS_SERVER_PORT = _port("MODBUS", 502)
+OPCUA_SERVER_PORT = _port("OPCUA", 4840)
 # Port 102 is OpenPLC's own S7/ISO-TSAP surface, 1102 is the separate s7com
 # service. test_connections scans 102, so keep that name pointing there.
-S7_SERVER_PORT = 102
-S7COM_PORT = 1102
-OPENPLC_PORT = 8080
-FUXA_PORT = 1881
-HWIO_PORT = 8090
+S7_SERVER_PORT = _port("S7", 102)
+S7COM_PORT = _port("S7COM", 1102)
+OPENPLC_PORT = _port("OPENPLC", 8080)
+FUXA_PORT = _port("FUXA", 1881)
+HWIO_PORT = _port("HWIO", 8090)
 
 OPCUA_SERVER_URL = f"opc.tcp://{SERVER_IP}:{OPCUA_SERVER_PORT}"
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -20,20 +20,25 @@ import os
 import pytest_asyncio
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
-from conftest import modbus_call
+from conftest import SERVER_IP, MODBUS_SERVER_PORT, OPCUA_SERVER_PORT, S7_SERVER_PORT, CONNECTION_TIMEOUT, READ_TIMEOUT, OPCUA_SERVER_URL, modbus_call
 from asyncua import Client, ua
+
+# Every test in this module talks to the running stack. Wait for it once and
+# fail with the exact list of missing services, instead of letting each test
+# discover the outage on its own and skip.
+pytestmark = pytest.mark.usefixtures("stack_ready")
 
 # Test Configuration Constants
 # Allow SERVER_IP to be overridden via environment variable for remote testing
-SERVER_IP = os.getenv('TEST_SERVER_IP', '127.0.0.1')  # Target server IP address for testing
-MODBUS_SERVER_PORT = 502           # Standard Modbus TCP port
-OPCUA_SERVER_PORT = 4840           # Standard OPC-UA port
-S7_SERVER_PORT = 102               # Standard Siemens S7 port
-CONNECTION_TIMEOUT = 20            # Connection timeout in seconds (increased for CI)
-READ_TIMEOUT = 10                  # Read operation timeout in seconds
+
+
+
+
+
+
 
 # OPC-UA Authentication Configuration
-OPCUA_SERVER_URL = f"opc.tcp://{SERVER_IP}:{OPCUA_SERVER_PORT}"
+
 USERNAME = "user1"                 # Default test username
 PASSWORD = "test"                  # Default test password
 
@@ -202,7 +207,7 @@ def test_write_single_register(modbus_client):
             error_msg = str(write_result)
             # Some Modbus servers may not support writes or close connection on write
             if "Connection unexpectedly closed" in error_msg or "Connection" in error_msg:
-                pytest.skip(f"Modbus server does not support write operations or closed connection: {error_msg}")
+                pytest.fail(f"Modbus write rejected by the server: {error_msg}")
             else:
                 pytest.fail(f"Modbus write error at register {register_address}: {write_result}")
 
@@ -234,7 +239,7 @@ def test_write_single_register(modbus_client):
     except ModbusException as e:
         pytest.fail(f"Modbus protocol exception during write operation: {e}")
     except ConnectionException as e:
-        pytest.skip(f"Connection issue during write operation - server may not support writes: {e}")
+        pytest.fail(f"Modbus connection failed during write: {e}")
 
 # ===============================================================================
 # OPC-UA Protocol Tests
@@ -278,15 +283,15 @@ async def test_opcua_server_running():
         )
 
     except ConnectionError as e:
-        pytest.skip(f"Failed to establish OPC-UA connection to {OPCUA_SERVER_URL}: {e}")
+        pytest.fail(f"OPC-UA connection to {OPCUA_SERVER_URL} failed: {e}")
     except TimeoutError as e:
-        pytest.skip(f"OPC-UA server connection timeout - server may need more time to initialize: {e}")
+        pytest.fail(f"OPC-UA connection timed out: {e}")
     except ua.UaError as e:
-        pytest.skip(f"OPC-UA protocol error: {e}")
+        pytest.fail(f"OPC-UA protocol error: {e}")
     except Exception as e:
         # Check if it's a timeout-related error
         if "timeout" in str(e).lower() or "TimeoutError" in str(type(e).__name__):
-            pytest.skip(f"OPC-UA server timeout - may need more initialization time: {e}")
+            pytest.fail(f"OPC-UA server timed out: {e}")
         pytest.fail(f"Unexpected error during OPC-UA test: {e}")
     finally:
         try:
@@ -345,7 +350,7 @@ def test_nmap_s7_info():
     
     # Handle nmap execution errors
     if stdout is None:
-        pytest.skip(f"Nmap execution failed: {stderr}")
+        pytest.fail(f"Nmap execution failed: {stderr}")
     
     # Nmap should execute successfully (return code 0 or 1 are acceptable)
     # Return code 1 typically means "no hosts up" but scan completed
@@ -367,7 +372,7 @@ def test_nmap_s7_info():
         )
     else:
         # Port closed/filtered - this might be expected in some test environments
-        pytest.skip(f"S7 service not accessible on port {S7_SERVER_PORT} - may not be configured")
+        pytest.fail(f"S7 service not reachable on port {S7_SERVER_PORT} although OpenPLC is part of the stack")
 
 
 # ===============================================================================
@@ -401,13 +406,14 @@ class TestWebServiceSecurity:
                 ]
                 
                 found_headers = [h for h in security_headers if h in headers]
-                
-                # This is informational - industrial systems may not have all headers
-                if not found_headers:
-                    pytest.skip(f"No security headers found in {url} - common in industrial systems")
-                
+
+                # Purely informational: this platform deliberately ships an
+                # unhardened HTTP surface, so the absence of these headers is
+                # the expected state and not a result worth skipping over.
+                print(f"security headers on {url}: {found_headers or 'none'}")
+
         except requests.exceptions.RequestException:
-            pytest.skip(f"Could not connect to {url} for header analysis")
+            pytest.fail(f"Could not connect to {url}")
 
 
 class TestModbusExtended:
@@ -423,7 +429,7 @@ class TestModbusExtended:
         )
         
         if not client.connect():
-            pytest.skip("Could not establish Modbus connection for extended tests")
+            pytest.fail("Could not establish Modbus connection")
         
         yield client
         
@@ -487,7 +493,7 @@ class TestModbusExtended:
             )
             
             if result.isError():
-                pytest.skip(f"Coils not available at address {coil_address}: {result}")
+                pytest.fail(f"Coil read failed at address {coil_address}: {result}")
             
             assert len(result.bits) >= coil_count, (
                 f"Expected at least {coil_count} coil bits, got {len(result.bits)}"
@@ -500,7 +506,7 @@ class TestModbusExtended:
                 )
                 
         except ModbusException as e:
-            pytest.skip(f"Coil reading not supported or failed: {e}")
+            pytest.fail(f"Coil read failed: {e}")
 
     def test_read_input_registers(self, connected_modbus_client):
         """
@@ -523,7 +529,7 @@ class TestModbusExtended:
             )
             
             if result.isError():
-                pytest.skip(f"Input registers not available at address {input_address}: {result}")
+                pytest.fail(f"Input register read failed at address {input_address}: {result}")
             
             assert len(result.registers) == input_count, (
                 f"Expected {input_count} input registers, got {len(result.registers)}"
@@ -539,7 +545,7 @@ class TestModbusExtended:
                 )
                 
         except ModbusException as e:
-            pytest.skip(f"Input register reading not supported: {e}")
+            pytest.fail(f"Input register read failed: {e}")
 
 
 class TestOpcuaExtended:
@@ -575,12 +581,12 @@ class TestOpcuaExtended:
             assert len(objects_children) >= 0, "Objects node accessible"
 
         except TimeoutError as e:
-            pytest.skip(f"OPC-UA server connection timeout - server may need more time to initialize: {e}")
+            pytest.fail(f"OPC-UA connection timed out: {e}")
         except ua.UaError as e:
-            pytest.skip(f"OPC-UA browsing not supported or failed: {e}")
+            pytest.fail(f"OPC-UA browsing failed: {e}")
         except Exception as e:  # pylint: disable=broad-except
             if "timeout" in str(e).lower() or "TimeoutError" in str(type(e).__name__):
-                pytest.skip(f"OPC-UA server timeout - may need more initialization time: {e}")
+                pytest.fail(f"OPC-UA server timed out: {e}")
             pytest.fail(f"Unexpected error during OPC-UA browsing: {e}")
         finally:
             try:
@@ -617,12 +623,12 @@ class TestOpcuaExtended:
             )
 
         except TimeoutError as e:
-            pytest.skip(f"OPC-UA server connection timeout - server may need more time to initialize: {e}")
+            pytest.fail(f"OPC-UA connection timed out: {e}")
         except ua.UaError as e:
-            pytest.skip(f"Server time reading not supported: {e}")
+            pytest.fail(f"Reading the OPC-UA server time failed: {e}")
         except Exception as e:  # pylint: disable=broad-except
             if "timeout" in str(e).lower() or "TimeoutError" in str(type(e).__name__):
-                pytest.skip(f"OPC-UA server timeout - may need more initialization time: {e}")
+                pytest.fail(f"OPC-UA server timed out: {e}")
             pytest.fail(f"Unexpected error reading server time: {e}")
         finally:
             try:
@@ -688,10 +694,10 @@ class TestOpcuaExtended:
                 pytest.fail(f"Authentication failed for user '{username}': {e}")
             pytest.fail(f"OPC-UA status code error: {e}")
         except TimeoutError as e:
-            pytest.skip(f"OPC-UA server connection timeout: {e}")
+            pytest.fail(f"OPC-UA connection timed out: {e}")
         except Exception as e:  # pylint: disable=broad-except
             if "timeout" in str(e).lower() or "TimeoutError" in str(type(e).__name__):
-                pytest.skip(f"OPC-UA server timeout: {e}")
+                pytest.fail(f"OPC-UA server timed out: {e}")
             pytest.fail(f"Unexpected error during OPC-UA traffic verification: {e}")
         finally:
             try:

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -20,6 +20,7 @@ import os
 import pytest_asyncio
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
+from conftest import modbus_call
 from asyncua import Client, ua
 
 # Test Configuration Constants
@@ -134,15 +135,15 @@ def test_read_holding_register(modbus_client):
     Args:
         modbus_client: Modbus TCP client fixture
     """
-    # Ensure connection is established
-    if not modbus_client.is_socket_open():
-        assert modbus_client.connect(), "Failed to connect to Modbus server"
-    
+    assert modbus_client.connect(), "Failed to connect to Modbus server"
+
     register_address = 1  # Test register address
     register_count = 1
-    
+
     try:
-        result = modbus_client.read_holding_registers(
+        result = modbus_call(
+            modbus_client,
+            modbus_client.read_holding_registers,
             address=register_address,
             count=register_count,
             device_id=1  # Default device ID
@@ -177,9 +178,7 @@ def test_write_single_register(modbus_client):
     Args:
         modbus_client: Modbus TCP client fixture
     """
-    # Ensure connection is established
-    if not modbus_client.is_socket_open():
-        assert modbus_client.connect(), "Failed to connect to Modbus server"
+    assert modbus_client.connect(), "Failed to connect to Modbus server"
 
     register_address = 1
     test_value = 123
@@ -187,7 +186,9 @@ def test_write_single_register(modbus_client):
 
     try:
         # Perform write operation
-        write_result = modbus_client.write_register(
+        write_result = modbus_call(
+            modbus_client,
+            modbus_client.write_register,
             address=register_address,
             value=test_value,
             device_id=slave_id
@@ -208,13 +209,13 @@ def test_write_single_register(modbus_client):
         # Small delay to ensure write is processed
         time.sleep(0.5)
 
-        # Reconnect if needed (some servers close after write)
-        if not modbus_client.is_socket_open():
-            if not modbus_client.connect():
-                pytest.skip("Connection closed after write - server may not support write operations")
-
-        # Verify write by reading back the value
-        read_result = modbus_client.read_holding_registers(
+        # Verify write by reading back the value.  modbus_call reconnects if
+        # the server closed the connection after the write, which it does; a
+        # plain is_socket_open() check cannot see that and used to let the read
+        # blow up instead.
+        read_result = modbus_call(
+            modbus_client,
+            modbus_client.read_holding_registers,
             address=register_address,
             count=1,
             device_id=slave_id

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -20,7 +20,9 @@ import os
 import pytest_asyncio
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
-from conftest import SERVER_IP, MODBUS_SERVER_PORT, OPCUA_SERVER_PORT, S7_SERVER_PORT, CONNECTION_TIMEOUT, READ_TIMEOUT, OPCUA_SERVER_URL, modbus_call
+from conftest import (SERVER_IP, MODBUS_SERVER_PORT, OPCUA_SERVER_PORT, S7_SERVER_PORT,
+                      OPENPLC_PORT, FUXA_PORT, HWIO_PORT, CONNECTION_TIMEOUT,
+                      READ_TIMEOUT, OPCUA_SERVER_URL, modbus_call)
 from asyncua import Client, ua
 
 # Every test in this module talks to the running stack. Wait for it once and
@@ -44,11 +46,13 @@ PASSWORD = "test"                  # Default test password
 
 # Web Services Configuration
 # Common industrial web interfaces and HMI ports
+# Derived from the port constants rather than repeating the numbers, so a stack
+# published on different host ports is reachable by overriding TEST_*_PORT.
 URLS = [
-    f"http://{SERVER_IP}",           # Main web interface
-    f"http://{SERVER_IP}:1881",      # Node-RED interface
-    f"http://{SERVER_IP}:8080",      # Alternative web service
-    f"http://{SERVER_IP}:8090"       # Hardware I/O virtual interface
+    f"http://{SERVER_IP}",                 # landing
+    f"http://{SERVER_IP}:{FUXA_PORT}",     # FUXA
+    f"http://{SERVER_IP}:{OPENPLC_PORT}",  # OpenPLC web
+    f"http://{SERVER_IP}:{HWIO_PORT}",     # hardware I/O
 ]
 
 # ===============================================================================

--- a/tests/test_opcua_auth.py
+++ b/tests/test_opcua_auth.py
@@ -25,12 +25,18 @@ import os
 from pathlib import Path
 from asyncua import Client, ua
 from asyncua.crypto.security_policies import SecurityPolicyBasic256Sha256
+from conftest import SERVER_IP, OPCUA_SERVER_PORT, OPCUA_SERVER_URL, CONNECTION_TIMEOUT
+
+# Every test in this module talks to the running stack. Wait for it once and
+# fail with the exact list of missing services, instead of letting each test
+# discover the outage on its own and skip.
+pytestmark = pytest.mark.usefixtures("stack_ready")
 
 # Test Configuration Constants
-SERVER_IP = os.getenv('TEST_SERVER_IP', '127.0.0.1')
-OPCUA_SERVER_PORT = 4840
-OPCUA_SERVER_URL = f"opc.tcp://{SERVER_IP}:{OPCUA_SERVER_PORT}"
-CONNECTION_TIMEOUT = 20
+
+
+
+
 
 # Username/Password Authentication Configuration
 USERNAME = "user1"
@@ -135,10 +141,10 @@ async def test_opcua_username_password_auth():
     except ConnectionError as e:
         pytest.fail(f"Failed to establish OPC-UA connection to {OPCUA_SERVER_URL}: {e}")
     except TimeoutError as e:
-        pytest.skip(f"OPC-UA server connection timeout - server may need more time: {e}")
+        pytest.fail(f"OPC-UA connection timed out: {e}")
     except Exception as e:
         if "timeout" in str(e).lower():
-            pytest.skip(f"OPC-UA server timeout - may need more initialization time: {e}")
+            pytest.fail(f"OPC-UA server timed out: {e}")
         pytest.fail(f"Unexpected error during username/password authentication: {e}")
     finally:
         try:
@@ -227,11 +233,11 @@ async def test_opcua_invalid_credentials_rejected():
             error_message = str(e)
 
         except TimeoutError as e:
-            pytest.skip(f"Server timeout during invalid credentials test: {e}")
+            pytest.fail(f"OPC-UA server timed out during the invalid-credentials test: {e}")
 
         except Exception as e:
             if "timeout" in str(e).lower():
-                pytest.skip(f"Server timeout: {e}")
+                pytest.fail(f"OPC-UA server timed out: {e}")
             # Other exceptions might indicate auth failure
             auth_failed = True
             error_message = str(e)
@@ -322,7 +328,7 @@ async def test_opcua_anonymous_access_denied():
 
     except Exception as e:
         if "timeout" in str(e).lower():
-            pytest.skip(f"Server timeout: {e}")
+            pytest.fail(f"OPC-UA server timed out: {e}")
         # Other errors might indicate anonymous access is blocked
         print(f"✓ Anonymous connection blocked: {str(e)[:100]}")
 
@@ -502,12 +508,12 @@ async def test_opcua_certificate_auth():
     except ConnectionError as e:
         pytest.fail(f"Failed to establish secure OPC-UA connection: {e}")
     except TimeoutError as e:
-        pytest.skip(f"OPC-UA server connection timeout: {e}")
+        pytest.fail(f"OPC-UA connection timed out: {e}")
     except FileNotFoundError as e:
         pytest.skip(f"Certificate file not found: {e}")
     except Exception as e:
         if "timeout" in str(e).lower():
-            pytest.skip(f"OPC-UA server timeout: {e}")
+            pytest.fail(f"OPC-UA server timed out: {e}")
         pytest.fail(f"Unexpected error during certificate authentication: {e}")
     finally:
         try:

--- a/tests/test_plant_model_parity.py
+++ b/tests/test_plant_model_parity.py
@@ -29,7 +29,8 @@ VIRTUAL = os.path.join(ROOT, "software", "hwio-virtual", "hardwareAbstraction.py
 def _read(path):
     if not os.path.exists(path):
         pytest.skip(f"{os.path.relpath(path, ROOT)} not present in this checkout")
-    return open(path, encoding="utf-8", errors="replace").read()
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        return fh.read()
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -17,7 +17,7 @@ import requests
 from pathlib import Path
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
-from conftest import SERVER_IP, CONNECTION_TIMEOUT, modbus_call
+from conftest import SERVER_IP, CONNECTION_TIMEOUT, OPENPLC_PORT, FUXA_PORT, modbus_call
 from dotenv import load_dotenv
 
 # Test Configuration
@@ -29,8 +29,6 @@ MODBUS_PORT = 502
 HPT_REGISTER = 1126  # High Pressure Tank register address
 
 # Web service ports
-OPENPLC_PORT = 8080
-FUXA_PORT = 1881
 
 
 # ===============================================================================

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -17,15 +17,15 @@ import requests
 from pathlib import Path
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
-from conftest import modbus_call
+from conftest import SERVER_IP, CONNECTION_TIMEOUT, modbus_call
 from dotenv import load_dotenv
 
 # Test Configuration
 # Allow SERVER_IP to be overridden via environment variable for remote testing
 # Default to localhost for consistency and isolation
-SERVER_IP = os.getenv('TEST_SERVER_IP', '127.0.0.1')
+
 MODBUS_PORT = 502
-CONNECTION_TIMEOUT = 10
+
 HPT_REGISTER = 1126  # High Pressure Tank register address
 
 # Web service ports
@@ -37,6 +37,9 @@ FUXA_PORT = 1881
 # Flood & Overwrite Training Tests
 # ===============================================================================
 
+# These talk to the running stack; the file-existence tests further down do
+# not, so the gate sits on the classes rather than the whole module.
+@pytest.mark.usefixtures("stack_ready")
 class TestFloodOverwrite:
     """
     Tests for the Flood & Overwrite training exercise.
@@ -148,7 +151,7 @@ class TestFloodOverwrite:
             if write_result.isError():
                 error_msg = str(write_result)
                 if "Connection unexpectedly closed" in error_msg or "Connection" in error_msg:
-                    pytest.skip(f"Server closed connection on write - may not support writes: {error_msg}")
+                    pytest.fail(f"Modbus write rejected by the server: {error_msg}")
                 else:
                     pytest.fail(f"Error writing to HPT register: {write_result}")
 
@@ -157,7 +160,7 @@ class TestFloodOverwrite:
             # is continuously updating this register based on the simulation
 
         except ConnectionException as e:
-            pytest.skip(f"Connection issue during write test: {e}")
+            pytest.fail(f"Modbus connection failed during the write test: {e}")
         except ModbusException as e:
             pytest.fail(f"Modbus exception during write test: {e}")
 
@@ -250,7 +253,7 @@ class TestFloodOverwrite:
             print(f"  Success rate: {write_count/(write_count+failed_writes)*100:.1f}%")
 
         except ConnectionException as e:
-            pytest.skip(f"Connection issue during flood simulation: {e}")
+            pytest.fail(f"Modbus connection failed during the flood simulation: {e}")
         except ModbusException as e:
             pytest.fail(f"Modbus exception during flood simulation: {e}")
 
@@ -282,7 +285,7 @@ class TestFloodOverwrite:
                 )
 
                 if write_result.isError():
-                    pytest.skip(f"Write operations not supported: {write_result}")
+                    pytest.fail(f"Modbus write rejected by the server: {write_result}")
 
                 successful_writes += 1
 
@@ -295,7 +298,7 @@ class TestFloodOverwrite:
             )
 
         except ConnectionException as e:
-            pytest.skip(f"Connection issue during write test: {e}")
+            pytest.fail(f"Modbus connection failed during the write test: {e}")
         except ModbusException as e:
             pytest.fail(f"Modbus exception during write test: {e}")
 
@@ -304,6 +307,9 @@ class TestFloodOverwrite:
 # Password Attack Training Tests
 # ===============================================================================
 
+# These talk to the running stack; the file-existence tests further down do
+# not, so the gate sits on the classes rather than the whole module.
+@pytest.mark.usefixtures("stack_ready")
 class TestPasswordAttack:
     """
     Tests for the Password Attack training exercise.

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -17,6 +17,7 @@ import requests
 from pathlib import Path
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ConnectionException, ModbusException
+from conftest import modbus_call
 from dotenv import load_dotenv
 
 # Test Configuration
@@ -85,11 +86,12 @@ class TestFloodOverwrite:
         Validates that register 1126 (HPT) is accessible for reading,
         which is necessary for the flood attack training scenario.
         """
-        if not modbus_client.is_socket_open():
-            assert modbus_client.connect(), "Failed to connect to Modbus server"
+        assert modbus_client.connect(), "Failed to connect to Modbus server"
 
         try:
-            result = modbus_client.read_holding_registers(
+            result = modbus_call(
+                modbus_client,
+                modbus_client.read_holding_registers,
                 address=HPT_REGISTER,
                 count=1,
                 device_id=1
@@ -117,14 +119,15 @@ class TestFloodOverwrite:
         Note: The HPT value may be overwritten by the PLC logic quickly,
         so we just verify the write succeeds, not persistence.
         """
-        if not modbus_client.is_socket_open():
-            assert modbus_client.connect(), "Failed to connect to Modbus server"
+        assert modbus_client.connect(), "Failed to connect to Modbus server"
 
         test_value = 50
 
         try:
             # Read original value
-            read_result = modbus_client.read_holding_registers(
+            read_result = modbus_call(
+                modbus_client,
+                modbus_client.read_holding_registers,
                 address=HPT_REGISTER,
                 count=1,
                 device_id=1
@@ -132,7 +135,9 @@ class TestFloodOverwrite:
             assert not read_result.isError(), f"Error reading HPT register: {read_result}"
 
             # Write test value - just verify write succeeds
-            write_result = modbus_client.write_register(
+            write_result = modbus_call(
+                modbus_client,
+                modbus_client.write_register,
                 address=HPT_REGISTER,
                 value=test_value,
                 device_id=1
@@ -168,8 +173,7 @@ class TestFloodOverwrite:
 
         Note: This is a brief test simulation (1 second), not a full attack.
         """
-        if not modbus_client.is_socket_open():
-            assert modbus_client.connect(), "Failed to connect to Modbus server"
+        assert modbus_client.connect(), "Failed to connect to Modbus server"
 
         flood_value = 10
         flood_duration = 1.0  # seconds
@@ -177,7 +181,9 @@ class TestFloodOverwrite:
 
         try:
             # Read original value to restore later
-            read_result = modbus_client.read_holding_registers(
+            read_result = modbus_call(
+                modbus_client,
+                modbus_client.read_holding_registers,
                 address=HPT_REGISTER,
                 count=1,
                 device_id=1
@@ -192,7 +198,9 @@ class TestFloodOverwrite:
 
             while (time.time() - start_time) < flood_duration:
                 try:
-                    result = modbus_client.write_register(
+                    result = modbus_call(
+                        modbus_client,
+                        modbus_client.write_register,
                         address=HPT_REGISTER,
                         value=flood_value,
                         device_id=1
@@ -257,8 +265,7 @@ class TestFloodOverwrite:
         updates this register. Instead, we verify that rapid successive writes
         are accepted by the server.
         """
-        if not modbus_client.is_socket_open():
-            assert modbus_client.connect(), "Failed to connect to Modbus server"
+        assert modbus_client.connect(), "Failed to connect to Modbus server"
 
         test_values = [10, 50, 100, 200]
         successful_writes = 0
@@ -266,7 +273,9 @@ class TestFloodOverwrite:
         try:
             for test_value in test_values:
                 # Write value
-                write_result = modbus_client.write_register(
+                write_result = modbus_call(
+                    modbus_client,
+                    modbus_client.write_register,
                     address=HPT_REGISTER,
                     value=test_value,
                     device_id=1


### PR DESCRIPTION
Two problems, both of which made a green tick mean less than it appeared to.

## 1. A flake that has been red one run in ten since June

`test_write_single_register` has failed on `main` ten times between 3 June and today — always the same step. The cause is in the test.

It already anticipates the behaviour; its own comments say *"some servers close after write"* and *"Reconnect if needed"*. But the guard cannot detect it:

```python
if not modbus_client.is_socket_open():
    modbus_client.connect()
```

`is_socket_open()` reports what the **local** transport believes. A FIN from the peer does not change that, so it still returns `True` after the server has closed. The reconnect never fires and the next read raises `ConnectionException`, landing in `except ModbusException: pytest.fail()` instead of the skip the author intended.

Reproduced exactly, against a server that closes after the write:

```
write ok, isError: False
is_socket_open() after the server closed: True
read raises: Connection unexpectedly closed 0.00...
```

Same message CI reports (*"...closed 0.004 seconds into read"*).

`conftest.modbus_call()` now runs the operation and, on a connection error, reconnects once and retries. A genuinely unreachable server still fails, because the retry fails too.

**Not explained:** *why* OpenPLC closes the connection. 40 runs against a real container and 30 more under simulated 50 Hz hwio load did not reproduce it locally. Most likely the runtime restarting its Modbus server when the PLC program starts, which in a freshly composed stack can land mid-test. The test has to survive that regardless.

## 2. 44 skips, most of them hiding real failures

A dead S7 service, an OPC-UA server that never answered, coils that could not be read — all skipped as *"may not be configured"*. Five of 53 tests were skipped in the last CI run, invisible behind a green tick.

**34 are now failures.** The 8 remaining are genuine environment gaps: a source file missing from the checkout, optional client certificates.

That is only honest if something guarantees the stack was up, so `conftest.py` gains a **readiness gate**. It polls every required port and fails once, naming exactly what is missing:

```
Failed: Stack did not become ready within 4s. Not reachable:
opcua (127.0.0.1:4840), s7com (127.0.0.1:1102), fuxa (127.0.0.1:1881), hwio (127.0.0.1:8090)
```

This replaces `sleep 120s` in the workflow, which waited by the clock rather than for readiness — and was why runs shortly after stack start were the ones that failed.

The gate is requested **per module**, not autouse, so tests that need no stack still run when nothing is up: **15 pass with the stack down**, where an autouse version errored all 53.

## Along the way

- **One definition of the constants** that lived in three files with values that had drifted — `CONNECTION_TIMEOUT` was 10 in one and 20 in the others, for no stated reason.
- While consolidating, `S7_SERVER_PORT` turned out to be **102** (OpenPLC's own ISO-TSAP surface), not s7com's **1102**. Both are now named and both are waited for.
- **`pytest.ini`**, which the suite had none of: `--strict-markers` so a typo in `@pytest.mark.asyncio` fails instead of silently dropping the test, an explicit `asyncio_mode` rather than a pytest-asyncio default that has changed between releases, and `-ra` so skips and failures are listed rather than counted.
- The **security-header test** no longer skips when it finds no headers. This platform deliberately ships an unhardened HTTP surface, so absence is the expected state — now reported, not dressed up as inconclusive.

## Verification

- With the stack down, the gate names the missing services and 15 tests still pass.
- Against a real OpenPLC container, the Modbus tests pass **five runs in a row**.
- Against a server that closes after every write, the old pattern fails and the new one passes.
- 53 tests collect under the new configuration; `actionlint` clean.

## Expect this to surface things

Converting skips to failures means CI may go red where it was green. That is the point — those runs were never actually passing, they were declining to look. If something fails here that was previously skipped, it is a finding, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QatVtMKCekLCozCLpDZb3