### PR TITLE
Build the STM32 firmware under emulation on the arm64 image runner

### DIFF
--- a/.devcontainer/stm32/docker-compose.yml
+++ b/.devcontainer/stm32/docker-compose.yml
@@ -2,6 +2,11 @@ services:
   dev:
     container_name: cybics-stm32
     image: cybics-stm32-dev
+    # The Zephyr SDK this image installs is published for x86_64 only, so the
+    # container is pinned to amd64 and runs emulated on arm64 hosts. What it
+    # produces is Cortex-M firmware for the nucleo_g070rb, which is identical
+    # whichever architecture cross-compiled it.
+    platform: linux/amd64
     build:
       context: ../..
       dockerfile: .devcontainer/stm32/Dockerfile

--- a/.github/workflows/rpiImage.yml
+++ b/.github/workflows/rpiImage.yml
@@ -49,6 +49,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_RO_USERNAME }}
           password: ${{ secrets.DOCKERHUB_RO_TOKEN }}
 
+      # The runner is arm64, but the stm32 devcontainer is amd64-only.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
Pushing the `v1.2.1` tag started the Raspberry Pi image workflow, which failed
after about a minute:

```
E: Package 'gcc-multilib' has no installation candidate
E: Unable to locate package g++-multilib
```

## Why

The workflow runs on `ubuntu-24.04-arm` so pi-gen and the nine containers build
natively rather than under emulation. But `software/build.sh` first compiles the
STM32 firmware in the stm32 devcontainer, and that image is amd64-only.

`multilib` is only the first symptom. `.devcontainer/stm32/Dockerfile` also
fetches the Zephyr SDK (line 87), the `arm-zephyr-eabi` toolchain (line 91) and
fixuid (line 99) as `linux-x86_64` archives. None of these are published for
arm64, so making the container build natively is not a matter of swapping a
package name.

## Why emulation is the right answer here

It is not needed natively. `west build -b nucleo_g070rb` cross-compiles for a
Cortex-M0+, so `build/zephyr/zephyr.bin` and `zephyr.elf` — the only outputs
`software/stm32/Dockerfile` consumes — are identical regardless of which host
architecture ran the compiler. Only that one container is emulated; the nine
that ship in the image keep building natively on arm64.

## Changes

- `.devcontainer/stm32/docker-compose.yml`: pin the service to `linux/amd64`
- `.github/workflows/rpiImage.yml`: set up QEMU before the build

The pin also fixes the devcontainer for anyone developing on an arm64
workstation, where it fails today for exactly the same reason.

## After merging

The `v1.2.1` tag points at 732b75d, which predates this fix, so it has to be
moved for the release to build:

```
git push origin --delete v1.2.1
git tag -d v1.2.1
git fetch origin
git tag -a v1.2.1 origin/main -m "Release v1.2.1"
git push origin v1.2.1
```