### PR TITLE
Cross-compile the STM32 firmware on amd64 instead of emulating it

### DIFF
--- a/.github/workflows/rpiImage.yml
+++ b/.github/workflows/rpiImage.yml
@@ -15,15 +15,53 @@ permissions:
   contents: write
 
 jobs:
+  firmware:
+    name: Build STM32 firmware
+    # The Zephyr toolchain ships for x86_64 only and cannot be emulated: fixuid
+    # is a Go binary, and Go's lock-free stack dies under qemu-user on aarch64
+    # with "fatal error: lfstack.push". So the firmware is cross-compiled on an
+    # amd64 runner and handed to the arm64 job. west targets the nucleo_g070rb,
+    # a Cortex-M0+, so the output does not depend on the host architecture.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Create environment files
+        run: ./.devcontainer/prepare-env.sh
+
+      - name: Build the firmware
+        working-directory: software
+        run: |
+          docker compose -f ../.devcontainer/stm32/docker-compose.yml build
+          docker compose -f ../.devcontainer/stm32/docker-compose.yml run --rm dev scripts/build.sh
+
+      - name: Upload the firmware
+        uses: actions/upload-artifact@v7
+        with:
+          name: stm32-firmware
+          path: |
+            software/stm32/build/zephyr/zephyr.bin
+            software/stm32/build/zephyr/zephyr.elf
+          if-no-files-found: error
+          retention-days: 1
+
   build:
     name: Build SD card image
     # Native arm64. pi-gen and the nine containers then build without qemu,
     # which is the difference between roughly 40 minutes and several hours.
     runs-on: ubuntu-24.04-arm
+    needs: firmware
     timeout-minutes: 300
 
     env:
       DOCKERHUB_RO_USERNAME: ${{ secrets.DOCKERHUB_RO_USERNAME }}
+      # The firmware comes from the job above; see software/build.sh.
+      SKIP_STM32_FIRMWARE: '1'
 
     steps:
       - name: Free up disk space
@@ -49,14 +87,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_RO_USERNAME }}
           password: ${{ secrets.DOCKERHUB_RO_TOKEN }}
 
-      # The runner is arm64, but the stm32 devcontainer is amd64-only.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: amd64
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Fetch the STM32 firmware
+        uses: actions/download-artifact@v7
+        with:
+          name: stm32-firmware
+          path: software/stm32/build/zephyr
 
       - name: Build image
         run: ./build.sh

--- a/software/build.sh
+++ b/software/build.sh
@@ -14,8 +14,24 @@ docker buildx ls | grep -q $name && docker buildx use $name
 docker buildx ls | grep -q $name || docker buildx create  --use --config config.toml --name $name
 docker buildx inspect --bootstrap
 
-docker compose -f ../.devcontainer/stm32/docker-compose.yml build
-docker compose -f ../.devcontainer/stm32/docker-compose.yml run --rm dev scripts/build.sh
+# The Zephyr toolchain in this devcontainer is published for x86_64 only, and
+# emulating it does not work: fixuid is a Go binary, and Go's lock-free stack
+# crashes under qemu-user on aarch64 ("fatal error: lfstack.push"). On arm64
+# hosts the firmware is therefore built elsewhere and dropped into
+# software/stm32/build, and this step is skipped.
+if [ "${SKIP_STM32_FIRMWARE:-0}" = "1" ]; then
+    for f in stm32/build/zephyr/zephyr.bin stm32/build/zephyr/zephyr.elf; do
+        if [ ! -f "$f" ]; then
+            echo "SKIP_STM32_FIRMWARE=1 but $f is missing." >&2
+            echo "Build it on an amd64 host first, or unset the variable." >&2
+            exit 1
+        fi
+    done
+    echo "Using the prebuilt STM32 firmware in software/stm32/build/zephyr."
+else
+    docker compose -f ../.devcontainer/stm32/docker-compose.yml build
+    docker compose -f ../.devcontainer/stm32/docker-compose.yml run --rm dev scripts/build.sh
+fi
 
 # Build function that handles both registry push and optional tarball export
 build_image() {


### PR DESCRIPTION
Follow-up to #216. Pinning the stm32 devcontainer to `linux/amd64` got it
building on the arm64 runner — the run got 21 minutes in instead of 1 — but the
build *inside* the container then died:

```
runtime: lfstack.push invalid packing: node=0xff37b2d7cbc0 cnt=0x1 ...
fatal error: lfstack.push
west: unknown command "build"
```

## What that actually is

Not Zephyr — qemu-user. `fixuid` is a Go binary, and Go's lock-free stack packs
a pointer and a counter into a single 64-bit word, assuming no more than 48
address bits. qemu hands out higher addresses when emulating x86_64 on aarch64,
so the packing check aborts. fixuid is the container entrypoint, so it dies
before the environment is set up, and `west` then runs against a workspace it
cannot read. The second error is a consequence of the first, not a separate
problem.

This is a known qemu/Go incompatibility rather than anything specific to this
repository, so emulating the toolchain is a dead end.

## Approach

Build the firmware where the toolchain is supported and pass the result along:

- a new `firmware` job on `ubuntu-24.04` cross-compiles and uploads
  `zephyr.bin` and `zephyr.elf`
- the arm64 `build` job gains `needs: firmware`, downloads them into
  `software/stm32/build/zephyr`, and sets `SKIP_STM32_FIRMWARE=1`
- `software/build.sh` honours that flag, and **fails** if the artefacts are not
  where it expects them, so a missing download cannot quietly ship an image
  with stale firmware

`west build -b nucleo_g070rb` targets a Cortex-M0+, so the output does not
depend on the host architecture, and `software/stm32/Dockerfile` consumes
nothing else from that build. The nine containers that ship in the image keep
building natively on arm64.

The QEMU step from #216 is removed again, since nothing is emulated any more.
The `linux/amd64` pin on the devcontainer stays: it is correct independently of
this, and it fixes the container for anyone on an arm64 workstation.

## Verified

Both branches of the new guard were exercised directly: missing artefacts exit
1 with a message naming the file, present artefacts exit 0 and skip the
devcontainer step.

## After merging

`v1.2.1` points at 84e1ad2, which predates this, so it has to be moved again:

```
git push origin --delete v1.2.1 && git tag -d v1.2.1
git fetch origin && git tag -a v1.2.1 origin/main -m "Release v1.2.1"
git push origin v1.2.1
```