### PR TITLE
Wait for an OPC-UA session, not just an open port

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,11 @@ HWIO_PORT = _port("HWIO", 8090)
 
 OPCUA_SERVER_URL = f"opc.tcp://{SERVER_IP}:{OPCUA_SERVER_PORT}"
 
+# Only used by the readiness probe below; the tests carry their own copies
+# because test_opcua_auth deliberately varies them.
+OPCUA_USERNAME = os.getenv("TEST_OPCUA_USER", "user1")
+OPCUA_PASSWORD = os.getenv("TEST_OPCUA_PASSWORD", "test")
+
 # Services the suite needs, and how long to wait for each on start-up.  The
 # workflow starts the stack immediately before running the suite, so the first
 # test can otherwise race the containers.
@@ -80,6 +85,41 @@ def wait_for_port(host, port, timeout, interval=1.0):
     return False
 
 
+
+def opcua_accepts_sessions(timeout, interval=1.0):
+    """Poll until the OPC-UA server completes a session, not just a TCP accept.
+
+    wait_for_port is not enough here.  The server binds its listener before it
+    can serve a session, so a connect issued in that window runs into its own
+    timeout and the test fails with "connection timed out" even though the
+    stack is merely still starting.  Modbus has the same shape of problem one
+    layer down, which is what modbus_call below deals with.
+
+    Returns True once a session was established and cleanly closed.
+    """
+    import asyncio
+
+    from asyncua import Client
+
+    async def attempt():
+        client = Client(OPCUA_SERVER_URL)
+        client.set_user(OPCUA_USERNAME)
+        client.set_password(OPCUA_PASSWORD)
+        client.timeout = 5
+        await client.connect()
+        try:
+            return True
+        finally:
+            await client.disconnect()
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            return asyncio.run(attempt())
+        except Exception:
+            time.sleep(interval)
+    return False
+
 @pytest.fixture(scope="session")
 def stack_ready():
     """Wait for the whole stack once, and say plainly which parts never came up.
@@ -98,6 +138,13 @@ def stack_ready():
         remaining = max(1, deadline - time.monotonic())
         if not wait_for_port(SERVER_IP, port, remaining):
             missing.append(f"{name} ({SERVER_IP}:{port})")
+
+    # An open port 4840 does not mean the OPC-UA server will serve a session.
+    if not missing:
+        remaining = max(1, deadline - time.monotonic())
+        if not opcua_accepts_sessions(remaining):
+            missing.append(f"opcua session ({OPCUA_SERVER_URL})")
+
     if missing:
         pytest.fail(
             "Stack did not become ready within "


### PR DESCRIPTION
The pytest run on main after #217 failed:

```
FAILED tests/test_connections.py::test_opcua_server_running
  - Failed: OPC-UA connection timed out
1 failed, 51 passed, 1 skipped in 9.62s
```

Nothing in #217 touches OPC-UA — it changed `software/build.sh` and the image
workflow — and the scheduled run three hours earlier was green. This is a race,
not a regression from that merge.

## Cause

`tests/conftest.py` gates the suite on `wait_for_port`, which polls TCP 4840.
The OPC-UA server binds its listener before it can serve a session, so a
connect issued in that window runs into its own timeout. The gate then declares
the stack ready and the first test that opens a session pays for it. Nine
seconds for the whole suite is the giveaway: the stack was still starting.

Same shape as the Modbus problem `modbus_call` already handles, one layer up —
a readiness check that looks at the socket instead of the protocol.

## Fix

The gate now completes a real OPC-UA session before declaring the stack ready.

The eight `client.connect()` sites in the two OPC-UA modules are deliberately
left alone: `test_opcua_auth` makes connections that are *supposed* to fail,
and a blanket retry there would hide genuine authentication regressions.

## Verified

Against a local asyncua server in three states:

| State | Result |
|---|---|
| nothing listening | `False` at the deadline (6.2s of a 6s budget), no hang |
| server running | `True` in 0.2s — no cost when the stack is already up |
| server appears after 10s | `True` after 11.2s — the retry path |

The middle row matters as much as the last: the probe must not slow down the
normal case.