### PR TITLE
Look up the station WiFi profile on every pass, not once at startup

### DIFF
--- a/software/hwio-raspberry/hardwareIO.py
+++ b/software/hwio-raspberry/hardwareIO.py
@@ -157,6 +157,39 @@ def thread_openplc():
   # Should never be reached
   client.close() # Disconnect device
 
+
+# The AP profile, and the station profile the image ships as a starting point.
+AP_CONNECTION = 'cybics'
+SHIPPED_STATION_CONNECTION = 'cybics-station'
+
+
+def detect_station_connection():
+  """Pick the WiFi profile to use for station mode, or None if there is none.
+
+  Anything that is not the AP qualifies, which covers the naming a stock
+  Raspberry Pi OS uses ('preconfigured', 'netplan-*', ...). A profile the user
+  created wins over the one the image ships, because cybics-station is only a
+  placeholder with ssid=cybics in it; whoever added their own network meant to
+  use it.
+
+  Re-run on every pass rather than once at startup: the documented way to
+  configure the station network is to add or edit a profile on a running
+  device, and a one-shot lookup would not see it until the container restarts.
+  """
+  shipped = None
+  try:
+    for conn in nmcli.connection():
+      if conn.conn_type != 'wifi' or conn.name == AP_CONNECTION:
+        continue
+      if conn.name == SHIPPED_STATION_CONNECTION:
+        shipped = conn.name
+        continue
+      return conn.name
+  except Exception as e:
+    logging.error(f"Error detecting Station mode connection: {str(e)}")
+    return None
+  return shipped
+
 # thread for network connection
 def thread_network():
   global dataID
@@ -175,24 +208,12 @@ def thread_network():
   except Exception as e:
     logging.error("Error getting current connection... " + str(e))
 
-  # Detect the Station mode connection (any WiFi connection that isn't 'cybics')
-  # This handles different naming conventions (e.g., 'preconfigured', 'netplan-*', etc.)
+  # Looked up again on every pass; see detect_station_connection.
   station_connection = None
-  try:
-    for conn in nmcli.connection():
-      # Find a WiFi connection that isn't the 'cybics' AP
-      if conn.conn_type == 'wifi' and conn.name != 'cybics':
-        station_connection = conn.name
-        logging.info(f"Detected Station mode connection: {station_connection}")
-        break
-    if station_connection is None:
-      logging.warning("No Station mode WiFi connection found (only 'cybics' AP exists)")
-  except Exception as e:
-    logging.error(f"Error detecting Station mode connection: {str(e)}")
 
   current_ssid = None
   try:
-    current_ssid = nmcli.connection.show('cybics')["802-11-wireless.ssid"]
+    current_ssid = nmcli.connection.show(AP_CONNECTION)["802-11-wireless.ssid"]
     logging.info(f"Current connection: {current_connection}, ap ssid: {current_ssid}")
   except Exception as e:
     logging.error("No current connection " + str(e))
@@ -209,6 +230,15 @@ def thread_network():
 
     except Exception as e:
       logging.error("Error in getting IP of wlan0 - " + str(e))
+
+    previous_station = station_connection
+    station_connection = detect_station_connection()
+    if station_connection != previous_station:
+      if station_connection is None:
+        logging.warning(
+          f"No Station mode WiFi profile found; only the {AP_CONNECTION} AP exists")
+      else:
+        logging.info(f"Using {station_connection} for Station mode")
 
     # The i2c thread fills dataID asynchronously, and on a fresh board that
     # takes a while -- the stm32 container has to flash the firmware first.
@@ -230,13 +260,13 @@ def thread_network():
       if current_ssid is None or current_ssid != ssid:
         try:
           logging.info(f"Configure ssid {ssid}")
-          nmcli.connection.modify('cybics', {'wifi.ssid': ssid})
+          nmcli.connection.modify(AP_CONNECTION, {'wifi.ssid': ssid})
           current_ssid = ssid
         except Exception as e:
           logging.error("Configure ssid failed - " + str(e))
           time.sleep(1)
 
-    connection = 'cybics' if dataID[12] == '1' else station_connection
+    connection = AP_CONNECTION if dataID[12] == '1' else station_connection
     if connection and current_connection != connection:
       try:
         logging.info(f"Enable connection {connection}")

--- a/software/stm32/src/main.c
+++ b/software/stm32/src/main.c
@@ -590,9 +590,9 @@ void thread_display(void *arg1, void *arg2, void *arg3)
 			} else if ((HPTpressure > 50) && (HPTpressure < 100)) {
 				snprintf(displayText, sizeof(displayText), "%-16s", "SV closed");
 			} else if (HPTpressure > 100) {
-				snprintf(displayText, sizeof(displayText), "%-16s", "Pressure too high");
+				snprintf(displayText, sizeof(displayText), "%-16s", "Pressure high");
 			} else if (HPTpressure <= 50) {
-				snprintf(displayText, sizeof(displayText), "%-16s", "Pressure too low");
+				snprintf(displayText, sizeof(displayText), "%-16s", "Pressure low");
 			}
 			lcd_set_cursor(&lcd, 1, 0);
 			lcd_print(&lcd, displayText);

--- a/tests/test_hwio_wifi.py
+++ b/tests/test_hwio_wifi.py
@@ -1,0 +1,84 @@
+"""Which WiFi profile hwio-raspberry picks for station mode.
+
+The device ships with two NetworkManager profiles: the 'cybics' access point,
+and 'cybics-station' as a starting point for the network the user wants to join.
+Choosing between those and anything the user adds is what decides whether the
+WiFi button works, so it is worth pinning down.
+
+hardwareIO imports Raspberry Pi hardware modules and touches GPIO and i2c at
+import time, none of which exists on a CI runner, so those are stubbed before
+the import.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+HWIO = Path(__file__).resolve().parent.parent / "software" / "hwio-raspberry" / "hardwareIO.py"
+
+
+@pytest.fixture(scope="module")
+def hwio():
+    """Import hardwareIO with the hardware-facing modules stubbed out."""
+    stubs = {
+        name: mock.MagicMock()
+        for name in ("RPi", "RPi.GPIO", "smbus", "smbus2", "nmcli",
+                     "pymodbus", "pymodbus.client")
+    }
+    with mock.patch.dict(sys.modules, stubs):
+        spec = importlib.util.spec_from_file_location("hardwareIO", HWIO)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+def connections(*specs):
+    """Build what nmcli.connection() returns: (name, conn_type) pairs."""
+    return [SimpleNamespace(name=n, conn_type=t, device="wlan0") for n, t in specs]
+
+
+AP = ("cybics", "wifi")
+SHIPPED = ("cybics-station", "wifi")
+USER = ("MyHomeNetwork", "wifi")
+ETHERNET = ("Wired connection 1", "ethernet")
+
+
+@pytest.mark.parametrize("listed, expected", [
+    # Nothing but the access point: station mode is impossible, and saying so
+    # beats silently picking the AP and fighting over the radio.
+    ([AP], None),
+    ([AP, ETHERNET], None),
+    # Only the shipped placeholder: use it.
+    ([AP, SHIPPED], "cybics-station"),
+    # A profile the user added beats the placeholder, whichever order nmcli
+    # happens to list them in. This is the case the old code got wrong: it took
+    # the first non-AP profile and stopped.
+    ([AP, SHIPPED, USER], "MyHomeNetwork"),
+    ([AP, USER, SHIPPED], "MyHomeNetwork"),
+    # Ethernet is not a candidate.
+    ([AP, ETHERNET, SHIPPED], "cybics-station"),
+])
+def test_picks_the_right_profile(hwio, listed, expected):
+    with mock.patch.object(hwio.nmcli, "connection", return_value=connections(*listed)):
+        assert hwio.detect_station_connection() == expected
+
+
+def test_a_profile_added_later_is_picked_up(hwio):
+    """The documented way to configure station WiFi is to add a profile on a
+    running device, so the lookup has to happen again rather than once."""
+    before = connections(AP, SHIPPED)
+    after = connections(AP, SHIPPED, USER)
+
+    with mock.patch.object(hwio.nmcli, "connection", return_value=before):
+        assert hwio.detect_station_connection() == "cybics-station"
+    with mock.patch.object(hwio.nmcli, "connection", return_value=after):
+        assert hwio.detect_station_connection() == "MyHomeNetwork"
+
+
+def test_a_broken_nmcli_yields_no_profile(hwio):
+    """nmcli failing must not take the network thread down with it."""
+    with mock.patch.object(hwio.nmcli, "connection", side_effect=RuntimeError("nmcli is unhappy")):
+        assert hwio.detect_station_connection() is None


### PR DESCRIPTION
Two defects found while reading `hardwareIO.py` and `main.c` end to end. Both
predate the protobuf work in #219 and are independent of it.

## The station profile was resolved once

`thread_network` looked up `station_connection` before entering its loop and
took the first WiFi profile that was not the `cybics` AP, stopping there.

**A profile added later was never seen.** The documented way to configure the
station network is to add or edit a profile on a running device. With a one-shot
lookup that does not take effect until the container restarts, which is the
opposite of what the instructions say.

**The shipped placeholder could win.** The image ships `cybics-station` as a
starting point, with `ssid=cybics` in it. If someone creates their own profile
instead of editing that one, which of the two is picked depends on the order
nmcli happens to list them in.

`detect_station_connection` now runs on every pass, prefers a user-created
profile over the shipped placeholder, and logs only when the answer changes so
the choice stays visible without a line every second.

## A status line did not fit the display

`"Pressure too high"` is seventeen characters on a sixteen-column LCD, and
`%-16s` is a *minimum* width, so `snprintf` wrote all seventeen. Both pressure
lines are shortened rather than only the long one, so the pair stays
symmetrical. All ten status strings now fit:

```
16 AP mode: cybics-     13 Pressure high
15 Danger! BlowOut      12 Pressure low
11 Operational           7 Status:
16 Physical/real:        9 SV closed
10 WiFi error           13 Wifi STA mode
```

## Tests

`tests/test_hwio_wifi.py` pins the selection down: AP only, placeholder only, a
user profile in either order relative to the placeholder, ethernet ignored, a
profile appearing later, and nmcli raising.

They earn their place — against the old implementation two of the eight fail:

```
FAILED test_picks_the_right_profile[listed3-MyHomeNetwork]
FAILED test_a_profile_added_later_is_picked_up
2 failed, 6 passed
```

`hardwareIO` touches GPIO and i2c at import time, so the test stubs the
hardware-facing modules before importing it. No hardware needed, and it runs in
the existing pytest job.