### PR TITLE
fix(rpi-image): keep NetworkManager off Docker's veth interfaces

### DIFF
--- a/software/installRPI.sh
+++ b/software/installRPI.sh
@@ -218,6 +218,18 @@ ssh "$DEVICE_USER"@"$DEVICE_IP" /bin/bash <<EOF
 EOF
 
 ###
+### Keep NetworkManager off Docker's interfaces
+###
+echo -ne "${GREEN}# Keep NetworkManager off Docker's interfaces ... \n${ENDCOLOR}"
+ssh "$DEVICE_USER"@"$DEVICE_IP" /bin/bash <<EOF
+    set -e
+    sudo install -d -m 755 /etc/NetworkManager/conf.d
+    printf '[keyfile]\nunmanaged-devices=interface-name:veth*;interface-name:br-*;interface-name:docker0\n' \
+        | sudo tee /etc/NetworkManager/conf.d/10-docker-unmanaged.conf > /dev/null
+    sudo nmcli general reload
+EOF
+
+###
 ### Enable I2C
 ###
 echo -ne "${GREEN}# Enable I2C on the RPi ... \n${ENDCOLOR}"

--- a/software/rpi-image/stage-cybics/01-configure-system/00-run.sh
+++ b/software/rpi-image/stage-cybics/01-configure-system/00-run.sh
@@ -8,6 +8,8 @@ install -m 644 files/zramswap "${ROOTFS_DIR}/etc/default/zramswap"
 # NetworkManager configuration
 install -d -m 755 "${ROOTFS_DIR}/etc/NetworkManager"
 install -m 644 files/NetworkManager.conf "${ROOTFS_DIR}/etc/NetworkManager/NetworkManager.conf"
+install -d -m 755 "${ROOTFS_DIR}/etc/NetworkManager/conf.d"
+install -m 644 files/10-docker-unmanaged.conf "${ROOTFS_DIR}/etc/NetworkManager/conf.d/10-docker-unmanaged.conf"
 
 # WiFi AP configuration for NetworkManager
 install -d -m 755 "${ROOTFS_DIR}/etc/NetworkManager/system-connections"

--- a/software/rpi-image/stage-cybics/01-configure-system/files/10-docker-unmanaged.conf
+++ b/software/rpi-image/stage-cybics/01-configure-system/files/10-docker-unmanaged.conf
@@ -1,0 +1,8 @@
+# NetworkManager.conf sets unmanaged-devices=none so that it owns wlan0.
+# Without this drop-in that also makes it own every interface Docker creates:
+# a container recreated after boot gets its veth treated as a new wired
+# device, NetworkManager runs DHCP on it, gives up after 45 seconds and
+# leaves the container cut off from its bridge. Containers started at boot
+# escaped only because NetworkManager saw them as externally configured.
+[keyfile]
+unmanaged-devices=interface-name:veth*;interface-name:br-*;interface-name:docker0


### PR DESCRIPTION
## Cause

The image's `NetworkManager.conf` sets `unmanaged-devices=none` so NetworkManager
owns `wlan0` for the AP/station switch. That also makes it own every interface
Docker creates. Containers started at boot are left alone because NetworkManager
sees them as externally configured, but a container recreated afterwards gets
its veth treated as a new wired device: NetworkManager runs DHCP on it, fails
after 45 seconds with `ip-config-unavailable`, and the container is cut off
from `br-cybics`.

Seen on a v1.2.1 image after `docker compose up -d hwio`: the recreated hwio
container could not reach `openplc:502` while the host and the boot-time
containers still could. Journal on the device:

```
device (veth11ae0f3): state change: ip-config -> failed (reason 'ip-config-unavailable')
device (veth11ae0f3): Activation: failed for connection 'Wired connection 4'
```

## Fix

A `conf.d` drop-in that marks `veth*`, `br-*` and `docker0` unmanaged, installed
by the image stage. `installRPI.sh` writes the same drop-in on the manual path so
both deployments behave alike.

## Verified

On a Raspberry Pi Zero 2 W running the v1.2.1 image, the drop-in was written by
hand and NetworkManager reloaded. Afterwards a force-recreated hwio container
reached `openplc:502` immediately, all Docker interfaces show as `unmanaged` in
`nmcli device status`, and the AP on `wlan0` stayed up throughout.

The `installRPI.sh` change is syntax-checked only; it runs those same two
commands over SSH. The virtual stack suite does not exercise the image; CI runs
it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
