### PR TITLE
fix(landing): make flood, fuzzing and mitm flags earned by the attack

### DIFF
--- a/software/landing/ctf_config.json
+++ b/software/landing/ctf_config.json
@@ -75,9 +75,11 @@
           "title": "Flood & Overwrite",
           "description": "Test system resilience against flooding attacks",
           "points": 200,
+          "type": "verify",
+          "verify_module": "check_flood_attack",
           "tag": "exploit",
           "flag": "CybICS(flood_attack_successful)",
-          "hint": "Overwhelm the system with excessive requests or data",
+          "hint": "Flood the HPT setpoint register with Modbus writes, then click Verify.",
           "training_content": "training/flood_overwrite/README.md"
         },
         {
@@ -105,9 +107,11 @@
           "title": "Fuzzing Modbus",
           "description": "Test Modbus protocol robustness",
           "points": 300,
+          "type": "verify",
+          "verify_module": "check_fuzzing_attack",
           "tag": "exploit",
           "flag": "CybICS(modbus_fuzzing_complete)",
-          "hint": "Send malformed or unexpected data to test protocol handling",
+          "hint": "Fuzz the Modbus server including diagnostic function codes, then click Verify.",
           "training_content": "training/fuzzingMB/README.md"
         }
       ]
@@ -121,9 +125,11 @@
           "title": "Man-in-the-Middle (MitM)",
           "description": "Learn about network interception",
           "points": 350,
+          "type": "verify",
+          "verify_module": "check_mitm_attack",
           "tag": "exploit",
           "flag": "CybICS(mitm_attack_successful)",
-          "hint": "Position yourself between communicating devices",
+          "hint": "Run the arpspoof man-in-the-middle between FUXA and the PLC, then click Verify.",
           "training_content": "training/mitm/README.md"
         },
         {

--- a/software/landing/modules/defense_checks/_ids_rule.py
+++ b/software/landing/modules/defense_checks/_ids_rule.py
@@ -1,0 +1,38 @@
+"""
+Shared helper for CTF checks that confirm an attack was actually carried out.
+
+The IDS sniffs all lab traffic and raises a named alert for each attack
+signature. A verified offensive challenge passes when its signature has fired,
+so the flag is earned by performing the attack rather than by reading a static
+string. This keeps the plant model untouched and reuses detection that already
+exists.
+"""
+import requests
+
+from utils.logger import logger
+
+IDS_URL = "http://localhost:8443"
+
+
+def rule_fired(rule_names):
+    """Whether any of the given IDS rules has an alert.
+
+    Returns (fired, error_message, error_checks). On success error_message is
+    "" and error_checks is []; on an IDS problem fired is False, error_message
+    explains it, and error_checks holds a check row to surface to the player.
+    """
+    if isinstance(rule_names, str):
+        rule_names = [rule_names]
+    try:
+        resp = requests.get(f"{IDS_URL}/api/rules/stats", timeout=5)
+        stats = resp.json()
+    except requests.exceptions.ConnectionError:
+        return (False, "Cannot reach the IDS service",
+                [{"name": "IDS reachable", "passed": False,
+                  "detail": "Cannot reach the IDS at port 8443"}])
+    except Exception as e:
+        logger.error(f"IDS rule check error: {e}")
+        return False, f"Verification error: {e}", []
+
+    fired = any(stats.get(r, {}).get("count", 0) for r in rule_names)
+    return fired, "", []

--- a/software/landing/modules/defense_checks/check_flood_attack.py
+++ b/software/landing/modules/defense_checks/check_flood_attack.py
@@ -1,0 +1,21 @@
+"""CTF check: the Modbus write flood against the plant actually happened."""
+from modules.defense_checks._ids_rule import rule_fired
+
+
+def verify():
+    fired, err, err_checks = rule_fired("modbus_flood")
+    if err:
+        return {"success": False, "message": err, "checks": err_checks}
+    checks = [{
+        "name": "Modbus write flood observed",
+        "passed": fired,
+        "detail": "A high-rate burst of Modbus writes to the plant was seen on the wire."
+        if fired else
+        "No write flood detected yet. Run the flood against the HPT register and try again.",
+    }]
+    return {
+        "success": fired,
+        "message": "Flood attack confirmed." if fired
+        else "Perform the write flood, then verify again.",
+        "checks": checks,
+    }

--- a/software/landing/modules/defense_checks/check_fuzzing_attack.py
+++ b/software/landing/modules/defense_checks/check_fuzzing_attack.py
@@ -1,0 +1,21 @@
+"""CTF check: the Modbus fuzzer exercised non-standard function codes."""
+from modules.defense_checks._ids_rule import rule_fired
+
+
+def verify():
+    fired, err, err_checks = rule_fired("modbus_diagnostic")
+    if err:
+        return {"success": False, "message": err, "checks": err_checks}
+    checks = [{
+        "name": "Malformed / non-standard Modbus traffic observed",
+        "passed": fired,
+        "detail": "The plant received diagnostic or non-standard Modbus function codes."
+        if fired else
+        "No fuzzing traffic detected yet. Run the Modbus fuzzer against the plant and try again.",
+    }]
+    return {
+        "success": fired,
+        "message": "Fuzzing confirmed." if fired
+        else "Run the Modbus fuzzer, then verify again.",
+        "checks": checks,
+    }

--- a/software/landing/modules/defense_checks/check_mitm_attack.py
+++ b/software/landing/modules/defense_checks/check_mitm_attack.py
@@ -1,0 +1,26 @@
+"""CTF check: a man-in-the-middle between FUXA and the PLC actually happened.
+
+Either method in the how-to leaves a trace the IDS raises: arpspoof poisons the
+ARP table (arp_spoof), and the socket proxy relays manipulated writes to OpenPLC
+from a host that is not an authorised writer (modbus_unauth_write).
+"""
+from modules.defense_checks._ids_rule import rule_fired
+
+
+def verify():
+    fired, err, err_checks = rule_fired("arp_spoof")
+    if err:
+        return {"success": False, "message": err, "checks": err_checks}
+    checks = [{
+        "name": "Man-in-the-middle observed",
+        "passed": fired,
+        "detail": "ARP poisoning between FUXA and the PLC was seen on the wire."
+        if fired else
+        "No ARP poisoning detected yet. Run the arpspoof man-in-the-middle, then try again.",
+    }]
+    return {
+        "success": fired,
+        "message": "MITM attack confirmed." if fired
+        else "Perform the man-in-the-middle attack, then verify again.",
+        "checks": checks,
+    }

--- a/training/flood_overwrite/README.md
+++ b/training/flood_overwrite/README.md
@@ -61,7 +61,7 @@ The flag has the format `CybICS(flag)`.
 1. Run the provided `flooding_hpt.py` script to flood Modbus registers on the PLC
 2. While the attack is running, open the **FUXA HMI** and observe how the physical process responds to the manipulated register values
 3. You should see the high pressure tank (HPT) register values being overwritten, causing the compressor (C) to remain enabled continuously, which drives the HPT toward a critical pressure value
-4. After observing the impact, retrieve the flag
+4. After the flood, click **Verify** on the challenge page. It confirms the IDS saw the write flood and reveals the flag.
 
 ## 🛡️ Security Framework References
 
@@ -134,7 +134,5 @@ Run `python3 flooding_hpt.py` and check the FUXA HMI dashboard for changes in pr
   - Operator notifications for corrective measures
   - Potential actions: reducing heat or shutting down components
 
-  After completion, use the following flag:
-
-**Flag:** `CybICS(flood_attack_successful)`
+Flood the HPT setpoint register with Modbus writes, then click **Verify** on the challenge page. The flag is revealed once the flood has been observed on the wire.
 

--- a/training/fuzzingMB/README.md
+++ b/training/fuzzingMB/README.md
@@ -28,7 +28,7 @@ There are different approaches to network fuzzing:
 - **⚖️ Legal and Ethical Considerations** – Unauthorized fuzzing can violate laws
 
 ## 🎯 Task
-The target for this exercise is the **OpenPLC Modbus service running on port 502**. Your goal is to run the Modbus fuzzer against the PLC's Modbus port to test how the device handles malformed or unexpected Modbus/TCP messages. After completing the fuzzing exercise, you will receive the flag.
+The target for this exercise is the **OpenPLC Modbus service running on port 502**. Your goal is to run the Modbus fuzzer against the PLC's Modbus port to test how the device handles malformed or unexpected Modbus/TCP messages. After fuzzing, you verify the attack on the challenge page to receive the flag.
 
 The flag has the format `CybICS(flag)`.
 
@@ -37,7 +37,7 @@ The flag has the format `CybICS(flag)`.
 2. Install Python dependencies with pip
 3. Run the fuzzer against the OpenPLC Modbus service on port 502
 4. Select a fuzzing mode from the menu and let the fuzzer run to completion
-5. Retrieve the flag after completing the fuzzing exercise
+5. Include the diagnostic function-code fuzzing (Modbus FC 0x08) in your run, then click **Verify** on the challenge page. It confirms the fuzzer reached the PLC and reveals the flag.
 
 ## 🚀 Using the Modbus Fuzzer
 
@@ -134,6 +134,4 @@ Run the fuzzer with `python3 modbus_fuzzer.py`, enter the target IP and port 502
 
 ## 🔍 Solution
 
-After completion, use the following flag:
-
-**Flag:** `CybICS(modbus_fuzzing_complete)`
+Fuzz the OpenPLC Modbus service on port 502, including the diagnostic function codes, then click **Verify** on the challenge page. The flag is revealed once the fuzzing traffic has been observed.

--- a/training/mitm/README.md
+++ b/training/mitm/README.md
@@ -93,7 +93,7 @@ The flag has the format `CybICS(flag)`.
 2. Enable IP forwarding on the attack machine
 3. Run ARP spoofing to poison the ARP caches of both the PLC and HMI
 4. Start the provided mitm.py Modbus proxy script
-5. Observe the intercepted Modbus traffic and find the flag
+5. With the ARP man-in-the-middle running, click **Verify** on the challenge page. It confirms the IDS saw the ARP poisoning between FUXA and the PLC and reveals the flag.
 
 ## 🛡️ Security Framework References
 
@@ -137,6 +137,4 @@ Use `arpspoof -i eth0 -t <FUXA_IP> <OpenPLC_IP>` in one terminal and `arpspoof -
 
 ## 🔍 Solution
 
-After completion, use the following flag:
-
-**Flag:** `CybICS(mitm_attack_successful)`
+Run the arpspoof man-in-the-middle between FUXA and the PLC (the `arpspoof` steps above), then click **Verify** on the challenge page. The flag is revealed once the ARP poisoning has been observed on the wire.


### PR DESCRIPTION
Stacked on #229 (base is `fix/plc-programming-flag`), which generalises the
verify path and UI. Review or merge that first.

## Cause

`flood_overwrite`, `fuzzingMB` and `mitm` awarded flags that lived only in
`ctf_config.json`. The player did the attack, but nothing surfaced the flag, so
it was effectively read from the README and the attack was optional.

## Fix

Make each a verified challenge that confirms the attack's own IDS signature
fired, then reveals the flag. No plant changes, no new detection — it reuses the
IDS the lab already runs.

| challenge | signature |
|---|---|
| flood_overwrite | `modbus_flood` |
| fuzzingMB | `modbus_diagnostic` (diagnostic function-code fuzzing) |
| mitm | `arp_spoof` (the arpspoof MITM) |

Each keys on a distinct signature so performing one attack cannot satisfy
another. A shared `_ids_rule` helper queries the IDS `/api/rules/stats`. The
three how-tos now end in a **Verify** step instead of quoting the flag.

## Verified

Against the running IDS: with a write flood already in the alert buffer the
flood check passes; fuzzing and mitm correctly report not-done until their own
signature (`modbus_diagnostic`, `arp_spoof`) appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
