### PR TITLE
fix(opcua): let the network-segmentation defense challenge block the OPC-UA port

### DIFF
--- a/.devcontainer/virtual/docker-compose.yml
+++ b/.devcontainer/virtual/docker-compose.yml
@@ -50,6 +50,8 @@ services:
         ipv4_address: 172.18.0.3
 
   opcua:
+    cap_add:
+      - NET_ADMIN
     image: mniedermaier1337/cybicsopcua:${CYBICS_VERSION:-latest}
     build:
       context: ../../software/opcua

--- a/software/docker-compose.yaml
+++ b/software/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
         ipv4_address: 172.18.0.2
 
   opcua:
+    cap_add:
+      - NET_ADMIN
     image: localhost:5000/cybics-opcua:latest
     depends_on:
     - openplc

--- a/software/opcua/Dockerfile
+++ b/software/opcua/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12-alpine
 
+# iptables lets the network-segmentation defense challenge add a rule that
+# blocks the attack machine from the OPC-UA port (needs NET_ADMIN, granted in
+# the compose files).
+RUN apk add --no-cache iptables
+
 WORKDIR /CybICS
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt

--- a/software/rpi-image/stage-cybics/02-load-containers/files/docker-compose.yaml
+++ b/software/rpi-image/stage-cybics/02-load-containers/files/docker-compose.yaml
@@ -19,6 +19,8 @@ services:
         ipv4_address: 172.18.0.2
 
   opcua:
+    cap_add:
+      - NET_ADMIN
     image: cybics-opcua:latest
     depends_on:
     - openplc

--- a/training/defense_network/README.md
+++ b/training/defense_network/README.md
@@ -47,9 +47,9 @@ Apply iptables rules on each **target container** to drop inbound traffic from t
    ```
 
 2. Access the OPC-UA container and block the attacker:
+   The OPC-UA container is Alpine-based and has no `bash`, so run iptables directly:
    ```bash
-   docker exec -it <opcua_container> bash
-   iptables -A INPUT -s 172.18.0.100 -j DROP
+   docker exec <opcua_container> iptables -A INPUT -s 172.18.0.100 -j DROP
    ```
 
 3. Verify the rules are applied on each container:
@@ -119,8 +119,7 @@ Add `iptables -A INPUT -s 172.18.0.100 -j DROP` on both the OpenPLC and OPC-UA c
    ```
 2. Block the attacker on the OPC-UA container:
    ```bash
-   docker exec -it <opcua_container> bash
-   iptables -A INPUT -s 172.18.0.100 -p tcp --dport 4840 -j DROP
+   docker exec <opcua_container> iptables -A INPUT -s 172.18.0.100 -p tcp --dport 4840 -j DROP
    ```
 3. Click **Verify Defense** in the CTF interface to receive the flag.
 


### PR DESCRIPTION
## Cause

`defense_network_segmentation` could not be completed. Its how-to has the player
run `iptables` inside the OPC-UA container to drop the attack machine, and
`check_network_segmentation.py` requires that rule on OPC-UA. But the OPC-UA
image is `python:3.12-alpine` with no `iptables`, and the container had no
`NET_ADMIN`, so the rule could neither be applied nor listed. Alpine also has no
`bash`, so the documented `docker exec -it ... bash` step failed as well.

## Fix

- `software/opcua/Dockerfile`: `apk add --no-cache iptables`.
- Grant `cap_add: [NET_ADMIN]` to the `opcua` service in the virtual, physical
  and SD-image compose files.
- `training/defense_network/README.md`: run iptables directly via `docker exec`
  (no interactive shell), and note the container is Alpine.

Least privilege: NET_ADMIN only, not `privileged` (the OpenPLC container in the
same challenge is already privileged for its own iptables).

## Verified

Rebuilt the OPC-UA image; run with `--cap-add NET_ADMIN` it adds
`iptables -A INPUT -s 172.18.0.100 -j DROP` and lists it under `INPUT`, which is
exactly what `check_network_segmentation` reads. Full image build runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
