### PR TITLE
ci(stm32): retry the west/pip network steps so PyPI timeouts do not fail builds

### DIFF
--- a/.devcontainer/stm32/Dockerfile
+++ b/.devcontainer/stm32/Dockerfile
@@ -56,17 +56,21 @@ RUN python3 -m venv .venv
 ENV PATH=/home/docker/zephyrproject/.venv/bin:$PATH
 ENV VIRTUAL_ENV=/home/docker/zephyrproject/.venv
 
+# PyPI/git reads on CI runners time out intermittently; give pip a real retry
+# budget and retry the network-bound steps so a transient timeout is not fatal.
+ENV PIP_DEFAULT_TIMEOUT=120 PIP_RETRIES=5
+
 # Install west and pre-pin packages in virtual environment
 RUN pip install --upgrade pip setuptools wheel && \
     pip install west
 
 # Initialize workspace using manifest (downloads only required modules)
 RUN west init -l app && \
-    west update --narrow -o=--depth=1 && \
+    for i in 1 2 3; do west update --narrow -o=--depth=1 && break || { echo "west update retry $i"; sleep 15; }; done && \
     west zephyr-export
 
-# Install Python requirements using west (recommended method)
-RUN west packages pip --install
+# Install Python requirements using west (recommended method), with retries
+RUN for i in 1 2 3; do west packages pip --install && break || { echo "west packages pip retry $i"; sleep 15; }; done
 
 # Install the Zephyr SDK (ARM toolchain only).
 #

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -8,6 +8,10 @@ on:
 
 env:
   ZEPHYR_SDK_VERSION: 0.17.4
+  # PyPI reads on shared runners time out intermittently; give pip a real
+  # retry budget so a transient read timeout does not fail the build.
+  PIP_DEFAULT_TIMEOUT: "120"
+  PIP_RETRIES: "5"
 
 concurrency:
   # One run per workflow per ref.  Pull request runs are cancelled when a new
@@ -50,12 +54,15 @@ jobs:
 
     - name: Initialize Zephyr workspace (using project manifest)
       run: |
+        # Retry the network-bound steps: PyPI and git reads on shared runners
+        # occasionally time out, which is not a build failure.
+        retry() { n=0; until "$@"; do n=$((n+1)); [ $n -ge 3 ] && return 1; echo "retry $n: $*"; sleep 15; done; }
         west init -l software/stm32
         cd software
-        west update --narrow -o=--depth=1
+        retry west update --narrow -o=--depth=1
         # Pre-pin packages to avoid pip backtracking on complex dependency resolution
-        pip3 install --upgrade pip setuptools wheel setuptools_scm poetry-core protobuf grpcio-tools 
-        pip3 install -r zephyr/scripts/requirements.txt
+        retry pip3 install --upgrade pip setuptools wheel setuptools_scm poetry-core protobuf grpcio-tools
+        retry pip3 install -r zephyr/scripts/requirements.txt
 
     - name: Build STM32 firmware
       working-directory: software


### PR DESCRIPTION
## Cause

The `zephyr CI` and `devContainer` (raspberry) jobs on main failed
intermittently during Zephyr toolchain setup, while pip pulled packages from
PyPI:

```
pip._vendor.urllib3.exceptions.ReadTimeoutError:
HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Read timed out.
```

and once as a `west packages pip --install` error at the same step. These are
transient runner-to-PyPI/git read timeouts, not regressions in any merged
change — the commit that showed them (#228) only touches the attack-machine
image, which the firmware build does not use.

## Fix

- Set `PIP_DEFAULT_TIMEOUT=120` and `PIP_RETRIES=5` so pip itself retries slow
  reads instead of giving up.
- Wrap the network-bound steps — `west update`, the `pip3 install` lines, and
  `west packages pip --install` — in a short 3-attempt retry loop.

Applied in both `.github/workflows/buildTest.yml` and
`.devcontainer/stm32/Dockerfile`. The commands are otherwise unchanged.

## Verified

The retry helper and the Dockerfile retry loops are shell-syntax checked, and
`buildTest.yml` parses as YAML. The behavioural fix (surviving a transient PyPI
timeout) can only show on a flaky runner; the change adds retries around
unchanged commands, so a healthy run is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
