### PR TITLE
test(training): flood how-to earns the flag via Verify, not a quoted string

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -612,7 +612,9 @@ def test_flood_attack_readme_exists():
     # Verify README contains expected sections
     content = readme_path.read_text()
     assert 'Flood' in content or 'flood' in content, "README missing flood attack content"
-    assert 'CybICS(flood_attack_successful)' in content, "README missing flag information"
+    # The flood flag is earned by performing the attack and clicking Verify, not
+    # quoted in the README, so check the README documents that flow.
+    assert 'Verify' in content, "README missing the verification step for the flag"
 
 
 def test_dev_env_file_exists():


### PR DESCRIPTION
## Cause

pytest fails on main. Making `flood_overwrite` a verified challenge removed the
static `CybICS(flood_attack_successful)` string from its README (the flag is now
earned by performing the attack and clicking Verify), but
`test_flood_attack_readme_exists` still asserts that exact string is in the
README:

```
assert 'CybICS(flood_attack_successful)' in content
E   AssertionError: README missing flag information
```

## Fix

Assert the README documents the verification flow (`'Verify' in content`)
instead of a flag string it no longer quotes. No other assertion changes: the
password how-to still quotes both `CybICS(0penPLC)` and `CybICS(FU##A)`, which
that test checks.

## Verified

Locally: the `test_training.py` file-content tests (4) pass, and the stackless
suites (`test_i2c_framing`, `test_hwio_wifi`, `test_plant_model_parity`,
`test_ids_rules`) pass (36). The stack-dependent tests are unaffected by CTF
config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
