### PR TITLE
feat(landing): implement the Theory Path with illustrated background reading

### DIFF
--- a/doc/helper-scripts/record_demo.py
+++ b/doc/helper-scripts/record_demo.py
@@ -99,7 +99,22 @@ def walkthrough(page, mark):
         page.evaluate(f"{toggle}()")
         page.wait_for_timeout(800)
 
-    # 2. CTF training: the challenge overview, then one challenge with its flag.
+    # 2. Theory Path: the topic hub, then an illustrated article or two.
+    mark("Theory Path", "Illustrated background reading on ICS protocols, threats and defense")
+    view(page, "theory", 3000)
+    th = frame_of(page, "theory-iframe")
+    scroll(th, 3, dy=380, pause=1500)
+    mark("Reading a topic", "Each topic explains the theory with diagrams, then links to the lab")
+    page.evaluate("document.getElementById('theory-iframe').src = '/theory/ics-basics'")
+    page.wait_for_timeout(3000)
+    th = frame_of(page, "theory-iframe")
+    scroll(th, 5, dy=380, pause=1500)
+    page.evaluate("document.getElementById('theory-iframe').src = '/theory/modbus'")
+    page.wait_for_timeout(2500)
+    th = frame_of(page, "theory-iframe")
+    scroll(th, 4, dy=380, pause=1500)
+
+    # 3. CTF training: the challenge overview, then one challenge with its flag.
     mark("CTF training", "Challenges from reconnaissance to attack and defense, each with a flag")
     view(page, "ctf", 3000)
     ctf = frame_of(page, "ctf-iframe")
@@ -120,7 +135,7 @@ def walkthrough(page, mark):
             submit.click()
             page.wait_for_timeout(4000)
 
-    # 3. Virtual hardware: the board, then the 3D view with a slow rotation.
+    # 4. Virtual hardware: the board, then the 3D view with a slow rotation.
     mark("Virtual hardware", "The CybICS board simulated in software, same process model as the STM32")
     view(page, "vhardware", 5000)
     hw = frame_of(page, "vhardware-iframe")
@@ -139,7 +154,7 @@ def walkthrough(page, mark):
         page.wait_for_timeout(2500)
         click_text(hw, "Classic View", 2500)
 
-    # 4. OpenPLC: log in, dashboard, programs, live monitoring.
+    # 5. OpenPLC: log in, dashboard, programs, live monitoring.
     mark("OpenPLC", "The controller, running the IEC 61131-3 program of the plant")
     view(page, "openplc", 3000)
     plc = frame_of(page, "openplc-iframe")
@@ -156,7 +171,7 @@ def walkthrough(page, mark):
     mark("Live monitoring", "Inputs, outputs and variables of the running program")
     click_text(plc, "Monitoring", 4000)
 
-    # 5. FUXA: log in, pressure overview, system view.
+    # 6. FUXA: log in, pressure overview, system view.
     mark("FUXA HMI", "The operator view: pressures, valves, compressor state, trends")
     view(page, "fuxa", 5000)
     fuxa = frame_of(page, "fuxa-iframe")
@@ -182,7 +197,7 @@ def walkthrough(page, mark):
     click_text(fuxa, "Pressure", 4000)
     click_text(fuxa, "System", 3500)
 
-    # 6. IDS: overview, alerts, rules, challenges.
+    # 7. IDS: overview, alerts, rules, challenges.
     mark("Intrusion detection", "Alerts, detection rules mapped to MITRE ATT&CK for ICS, defense challenges")
     view(page, "ids", 3500)
     ids = frame_of(page, "ids-iframe")
@@ -192,7 +207,7 @@ def walkthrough(page, mark):
             btn.click()
             page.wait_for_timeout(3000)
 
-    # 7. Engineering workstation with the OpenPLC Editor opened.
+    # 8. Engineering workstation with the OpenPLC Editor opened.
     subprocess.run(["docker", "exec", ENGWS_CONTAINER, "pkill", "-f", "Beremiz.py"],
                    capture_output=True, timeout=10)
     subprocess.Popen(["docker", "exec", "-d", ENGWS_CONTAINER, "sh", "-c",
@@ -220,7 +235,7 @@ def walkthrough(page, mark):
             page.wait_for_timeout(900)
         page.wait_for_timeout(2000)
 
-    # 8. Attack machine, then back home.
+    # 9. Attack machine, then back home.
     mark("Attack machine", "Kali Linux with ICS tooling, the place to run the training modules from")
     view(page, "attackmachine", 6000)
     mark("", "")

--- a/software/landing/Dockerfile
+++ b/software/landing/Dockerfile
@@ -28,6 +28,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY software/landing/app.py ./
 COPY software/landing/ctf_config.json ./
+COPY software/landing/theory_config.json ./
 COPY software/landing/pics/ pics/
 COPY software/landing/templates/ templates/
 COPY software/landing/static/ static/

--- a/software/landing/app.py
+++ b/software/landing/app.py
@@ -18,6 +18,7 @@ from utils.logger import logger
 from modules.stats_collector import StatsCollector
 from modules.network_capture import NetworkCapture
 from modules.ctf_manager import CTFManager
+from modules.theory_manager import TheoryManager
 from modules.network_routes import register_network_routes
 
 # Initialize Flask application
@@ -42,6 +43,7 @@ logger.info('='*60)
 stats_collector = StatsCollector()
 network_capture = NetworkCapture()
 ctf_manager = CTFManager()
+theory_manager = TheoryManager()
 
 # Start background collection
 stats_collector.start()
@@ -334,6 +336,30 @@ def ctf_page():
                          challenges=ctf_manager.challenges,
                          solved=session['solved_challenges'],
                          total_points=session['total_points'])
+
+@app.route('/theory')
+def theory_page():
+    """Theory Path hub: sections of illustrated background-reading topics."""
+    initialize_session()
+    logger.info('Rendering Theory page')
+    return render_template('theory.html',
+                           config=theory_manager.config,
+                           sections=theory_manager.sections)
+
+
+@app.route('/theory/<topic_id>')
+def theory_topic(topic_id):
+    """A single theory article, rendered from Markdown (may contain SVG)."""
+    initialize_session()
+    topic, section = theory_manager.get_topic(topic_id)
+    if not topic:
+        logger.warning(f'Theory topic not found: {topic_id}')
+        return "Topic not found", 404
+    content = theory_manager.load_markdown_content(topic.get('content'))
+    return render_template('theory_article.html',
+                           topic=topic, section=section, content=content,
+                           config=theory_manager.config)
+
 
 @app.route('/ctf/challenge/<challenge_id>')
 def challenge_detail(challenge_id):

--- a/software/landing/modules/theory_manager.py
+++ b/software/landing/modules/theory_manager.py
@@ -1,0 +1,61 @@
+"""
+Theory Path management: structured background reading with inline diagrams.
+
+Mirrors the CTF manager: a JSON config groups topics into sections, and each
+topic renders a Markdown article (which may contain inline SVG diagrams) to
+HTML. Read progress is tracked client-side, so there is no server state here.
+"""
+import json
+import os
+import re
+
+import markdown
+
+from utils.logger import logger
+from utils.config import THEORY_CONFIG_FILE
+
+
+class TheoryManager:
+    def __init__(self):
+        self.config = self._load_config()
+        self.sections = self.config.get('sections', {})
+        logger.info(f"TheoryManager initialized with {self._count()} topics")
+
+    def _load_config(self):
+        try:
+            with open(THEORY_CONFIG_FILE, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except FileNotFoundError:
+            logger.error(f"Theory config not found: {THEORY_CONFIG_FILE}")
+            return {"sections": {}}
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing theory config: {e}")
+            return {"sections": {}}
+
+    def _count(self):
+        return sum(len(s.get('topics', [])) for s in self.sections.values())
+
+    def get_topic(self, topic_id):
+        for section in self.sections.values():
+            for topic in section.get('topics', []):
+                if topic['id'] == topic_id:
+                    return topic, section
+        return None, None
+
+    def load_markdown_content(self, relative_path):
+        if not relative_path:
+            return ""
+        full_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), relative_path)
+        try:
+            with open(full_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            content = re.sub(r'<details>', '<details markdown="1">', content)
+            content = re.sub(r'<summary>', '<summary markdown="1">', content)
+            return markdown.markdown(content, extensions=[
+                'fenced_code', 'codehilite', 'tables', 'nl2br', 'extra', 'md_in_html'])
+        except FileNotFoundError:
+            logger.warning(f"Theory content not found: {full_path}")
+            return f"<p><em>Theory content not available at: {relative_path}</em></p>"
+        except Exception as e:
+            logger.error(f"Error loading theory content {full_path}: {e}")
+            return f"<p><em>Error loading theory content: {e}</em></p>"

--- a/software/landing/templates/index.html
+++ b/software/landing/templates/index.html
@@ -2269,6 +2269,9 @@
 
             <!-- Training -->
             <div class="nav-section-label">Training</div>
+            <button id="theory-btn" class="nav-button" onclick="updateView('theory')" title="Theory Path">
+                <svg class="nav-icon"><use href="#i-book"/></svg><span class="nav-label">Theory Path</span>
+            </button>
             <button id="ctf-btn" class="nav-button" onclick="updateView('ctf')" title="CTF Training">
                 <svg class="nav-icon"><use href="#i-flag"/></svg><span class="nav-label">CTF Training</span>
             </button>
@@ -2358,11 +2361,11 @@
                                     <p class="learning-card-desc">Launch a guided 15-minute introduction to CybICS.</p>
                                 </div>
                             </div>
-                            <div class="learning-card learning-card-disabled">
+                            <div class="learning-card" onclick="updateView('theory')">
                                 <div class="learning-card-icon"><svg><use href="#i-book"/></svg></div>
                                 <div class="learning-card-body">
-                                    <div class="learning-card-title">Theory Path<span class="badge">COMING SOON</span></div>
-                                    <p class="learning-card-desc">Structured background reading covering ICS protocols, architectures, and threats for each module.</p>
+                                    <div class="learning-card-title">Theory Path</div>
+                                    <p class="learning-card-desc">Structured background reading covering ICS protocols, architectures, and threats, with diagrams. Each topic links to the matching challenge.</p>
                                 </div>
                             </div>
                             <div class="learning-card" onclick="updateView('ctf')">
@@ -2408,6 +2411,19 @@
             {% endfor %}
 
             <!-- CTF Training Card -->
+            <!-- Theory Path Card -->
+            <div id="theory-card" class="service-card hidden">
+                <iframe
+                    id="theory-iframe"
+                    class="service-iframe"
+                    data-src="/theory"
+                    title="Theory Path"
+                    allow="fullscreen"
+                    allowfullscreen="true"
+                    sandbox="allow-same-origin allow-scripts allow-popups allow-forms"
+                ></iframe>
+            </div>
+
             <div id="ctf-card" class="service-card hidden">
                 <iframe
                     id="ctf-iframe"
@@ -2477,7 +2493,7 @@
         // Store service IDs in a JavaScript array
         const serviceIds = [{% for service_id in services.keys() %}'{{ service_id }}',{% endfor %}];
         // Additional view IDs for CTF and Tools
-        const additionalViewIds = ['ctf', 'stats', 'network', 'webshell'];
+        const additionalViewIds = ['theory', 'ctf', 'stats', 'network', 'webshell'];
         const allViewIds = [...serviceIds, ...additionalViewIds];
 
         // Track current view

--- a/software/landing/templates/theory.html
+++ b/software/landing/templates/theory.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config.title or 'CybICS - Theory Path' }}</title>
+    <script>(function(){if(new URLSearchParams(location.search).get("theme")==="light")document.documentElement.classList.add("light-mode");})();</script>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { background:#1a1a1a; color:#e8e8e8; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; line-height:1.6; }
+        ::-webkit-scrollbar { width:8px; } ::-webkit-scrollbar-track { background:#1a1a1a; }
+        ::-webkit-scrollbar-thumb { background:#404040; border-radius:4px; } ::-webkit-scrollbar-thumb:hover { background:#ff6b00; }
+        header { background:#2d2d2d; padding:0.9rem 1.5rem; display:flex; justify-content:space-between; align-items:center; border-bottom:2px solid #ff6b00; position:sticky; top:0; z-index:10; }
+        header h1 { font-size:1.25rem; color:#ff6b00; }
+        .header-stats { display:flex; align-items:center; gap:1rem; font-size:0.85rem; }
+        .progress-bar-mini { width:140px; height:6px; background:#404040; border-radius:3px; overflow:hidden; }
+        .progress-bar-mini .fill { height:100%; background:#22c55e; width:0; transition:width .3s; }
+        .wrap { max-width:1000px; margin:0 auto; padding:1.5rem; }
+        .intro { color:#bbb; margin-bottom:1.5rem; }
+        .section { margin-bottom:2rem; }
+        .section-title { font-size:1.05rem; font-weight:700; color:#ff6b00; margin-bottom:0.25rem; }
+        .section-desc { color:#999; font-size:0.9rem; margin-bottom:1rem; }
+        .grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(300px,1fr)); gap:0.9rem; }
+        .card { display:flex; gap:0.8rem; background:#2d2d2d; border:1px solid #383838; border-left:3px solid #ff6b00; border-radius:0.5rem; padding:0.9rem 1rem; text-decoration:none; color:inherit; transition:border-color .15s, transform .1s; }
+        .card:hover { border-color:#ff6b00; transform:translateY(-1px); }
+        .card.read { border-left-color:#22c55e; }
+        .card-check { flex-shrink:0; width:22px; height:22px; border-radius:50%; border:2px solid #555; color:#555; display:flex; align-items:center; justify-content:center; font-size:0.8rem; margin-top:2px; }
+        .card.read .card-check { background:#22c55e; border-color:#22c55e; color:#fff; }
+        .card-title { font-weight:700; margin-bottom:0.2rem; }
+        .card-summary { color:#aaa; font-size:0.85rem; }
+        .card-meta { color:#ff8c3a; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.04em; margin-top:0.4rem; }
+        html.light-mode body { background:#f5f6f8; color:#1f2733; }
+        html.light-mode header { background:#fff; }
+        html.light-mode .card { background:#fff; border-color:#e2e6ec; box-shadow:0 2px 8px rgba(15,23,42,.06); }
+        html.light-mode .card-summary { color:#5b6675; }
+        html.light-mode header h1, html.light-mode .section-title { color:#b34700; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>&#128218; Theory Path</h1>
+        <div class="header-stats">
+            <span id="read-count">0 / 0 read</span>
+            <div class="progress-bar-mini"><div class="fill" id="progress-fill"></div></div>
+        </div>
+    </header>
+    <div class="wrap">
+        <p class="intro">{{ config.description }}</p>
+        {% for key, section in sections.items() %}
+        <div class="section">
+            <div class="section-title">{{ section.name }}</div>
+            <div class="section-desc">{{ section.description }}</div>
+            <div class="grid">
+                {% for topic in section.topics %}
+                <a class="card" href="/theory/{{ topic.id }}" data-id="{{ topic.id }}">
+                    <div class="card-check">&#10003;</div>
+                    <div>
+                        <div class="card-title">{{ topic.title }}</div>
+                        <div class="card-summary">{{ topic.summary }}</div>
+                        <div class="card-meta">{{ topic.minutes }} min read</div>
+                    </div>
+                </a>
+                {% endfor %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    <script>
+        function readSet() { try { return new Set(JSON.parse(localStorage.getItem('cybics-theory-read')||'[]')); } catch(e){ return new Set(); } }
+        (function(){
+            const read = readSet();
+            const cards = document.querySelectorAll('.card');
+            let done = 0;
+            cards.forEach(c => { if (read.has(c.dataset.id)) { c.classList.add('read'); done++; } });
+            document.getElementById('read-count').textContent = done + ' / ' + cards.length + ' read';
+            document.getElementById('progress-fill').style.width = cards.length ? (done/cards.length*100)+'%' : '0';
+        })();
+    </script>
+</body>
+</html>

--- a/software/landing/templates/theory_article.html
+++ b/software/landing/templates/theory_article.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CybICS - {{ topic.title }}</title>
+    <script>(function(){if(new URLSearchParams(location.search).get("theme")==="light")document.documentElement.classList.add("light-mode");})();</script>
+    <style>
+        * { box-sizing:border-box; margin:0; padding:0; }
+        body { background:#1a1a1a; color:#e8e8e8; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; line-height:1.7; }
+        ::-webkit-scrollbar { width:8px; } ::-webkit-scrollbar-track { background:#1a1a1a; }
+        ::-webkit-scrollbar-thumb { background:#404040; border-radius:4px; } ::-webkit-scrollbar-thumb:hover { background:#ff6b00; }
+        header { background:#2d2d2d; padding:0.8rem 1.5rem; display:flex; justify-content:space-between; align-items:center; border-bottom:2px solid #ff6b00; position:sticky; top:0; z-index:10; gap:1rem; }
+        .back { color:#ff6b00; text-decoration:none; font-size:0.85rem; border:1px solid #ff6b00; border-radius:0.25rem; padding:0.3rem 0.7rem; white-space:nowrap; }
+        .back:hover { background:#ff6b00; color:#1a1a1a; }
+        .head-title { font-size:1.05rem; color:#ff6b00; font-weight:700; }
+        .head-meta { font-size:0.72rem; color:#999; text-transform:uppercase; letter-spacing:0.04em; }
+        .mark-btn { background:#333; color:#e8e8e8; border:1px solid #555; border-radius:0.3rem; padding:0.35rem 0.8rem; cursor:pointer; font-size:0.8rem; white-space:nowrap; }
+        .mark-btn.read { background:#22c55e; border-color:#22c55e; color:#fff; }
+        .wrap { max-width:820px; margin:0 auto; padding:1.75rem 1.5rem 4rem; }
+        .article h1 { font-size:1.6rem; color:#ff6b00; margin:0 0 1rem; }
+        .article h2 { font-size:1.25rem; color:#ff8c3a; margin:2rem 0 0.6rem; border-bottom:1px solid #383838; padding-bottom:0.3rem; }
+        .article h3 { font-size:1.05rem; color:#ffb37a; margin:1.4rem 0 0.5rem; }
+        .article p { margin:0.7rem 0; }
+        .article ul, .article ol { margin:0.7rem 0 0.7rem 1.4rem; }
+        .article li { margin:0.3rem 0; }
+        .article code { background:#2d2d2d; padding:0.1rem 0.35rem; border-radius:0.25rem; font-size:0.9em; }
+        .article pre { background:#0f0f0f; border:1px solid #333; border-radius:0.5rem; padding:0.9rem; overflow-x:auto; }
+        .article pre code { background:none; padding:0; }
+        .article table { border-collapse:collapse; margin:1rem 0; width:100%; }
+        .article th, .article td { border:1px solid #383838; padding:0.4rem 0.7rem; text-align:left; font-size:0.9rem; }
+        .article th { background:#2d2d2d; color:#ff8c3a; }
+        .article blockquote { border-left:3px solid #ff6b00; background:#2d2d2d; padding:0.6rem 1rem; margin:1rem 0; color:#cfcfcf; }
+        .article figure { margin:1.4rem 0; text-align:center; }
+        .article figure svg { max-width:100%; height:auto; background:#141414; border:1px solid #333; border-radius:0.5rem; padding:0.8rem; color:#e8e8e8; }
+        .article figure svg text { fill:currentColor; }
+        .article figcaption { color:#999; font-size:0.82rem; margin-top:0.5rem; }
+        .related { margin-top:2.5rem; border-top:1px solid #383838; padding-top:1rem; }
+        .related h2 { font-size:1rem; color:#ff8c3a; margin-bottom:0.6rem; }
+        .related a { display:inline-block; margin:0.25rem 0.4rem 0.25rem 0; padding:0.35rem 0.8rem; border:1px solid #ff6b00; border-radius:0.3rem; color:#ff6b00; text-decoration:none; font-size:0.85rem; }
+        .related a:hover { background:#ff6b00; color:#1a1a1a; }
+        html.light-mode body { background:#f5f6f8; color:#1f2733; }
+        html.light-mode header { background:#fff; }
+        html.light-mode .article h1, html.light-mode .head-title { color:#b34700; }
+        html.light-mode .article code { background:#eef1f5; }
+        html.light-mode .article pre { background:#0f172a; }
+        html.light-mode .article figure svg { background:#fff; border-color:#e2e6ec; color:#1f2733; }
+        html.light-mode .article th { background:#eef1f5; color:#b34700; }
+    </style>
+</head>
+<body>
+    <header>
+        <a class="back" href="/theory">&#8592; Theory Path</a>
+        <div style="flex:1; min-width:0;">
+            <div class="head-title">{{ topic.title }}</div>
+            <div class="head-meta">{{ section.name }} &middot; {{ topic.minutes }} min read</div>
+        </div>
+        <button class="mark-btn" id="mark-btn" data-id="{{ topic.id }}">Mark as read</button>
+    </header>
+    <div class="wrap">
+        <article class="article">
+            {{ content | safe }}
+        </article>
+        {% if topic.related %}
+        <div class="related">
+            <h2>Put it into practice</h2>
+            {% for r in topic.related %}
+                <a href="/ctf/challenge/{{ r.id }}">&#127937; {{ r.label }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </div>
+    <script>
+        function readSet(){ try { return new Set(JSON.parse(localStorage.getItem('cybics-theory-read')||'[]')); } catch(e){ return new Set(); } }
+        function saveSet(s){ try { localStorage.setItem('cybics-theory-read', JSON.stringify([...s])); } catch(e){} }
+        (function(){
+            const btn=document.getElementById('mark-btn'); const id=btn.dataset.id; const read=readSet();
+            function paint(){ if(read.has(id)){ btn.classList.add('read'); btn.textContent='✓ Read'; } else { btn.classList.remove('read'); btn.textContent='Mark as read'; } }
+            paint();
+            btn.addEventListener('click', ()=>{ if(read.has(id)) read.delete(id); else read.add(id); saveSet(read); paint(); });
+        })();
+    </script>
+</body>
+</html>

--- a/software/landing/theory_config.json
+++ b/software/landing/theory_config.json
@@ -1,0 +1,446 @@
+{
+  "title": "CybICS - Theory Path",
+  "description": "Structured background reading on ICS protocols, architectures and threats, with diagrams. Each topic links to the matching hands-on challenge.",
+  "sections": {
+    "foundations": {
+      "name": "Foundations",
+      "icon": "book",
+      "description": "Start here. The concepts every later module builds on.",
+      "topics": [
+        {
+          "id": "ics-basics",
+          "title": "What is an ICS?",
+          "summary": "Operational technology versus IT, the Purdue model, and why safety and availability come first.",
+          "minutes": 6,
+          "content": "training/theory/foundations/ics-basics.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "physical_process",
+              "label": "Physical process challenge"
+            }
+          ]
+        },
+        {
+          "id": "plc-fundamentals",
+          "title": "PLCs and the scan cycle",
+          "summary": "How a PLC reads inputs, runs an IEC 61131-3 program, and drives outputs every cycle.",
+          "minutes": 6,
+          "content": "training/theory/foundations/plc-fundamentals.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "plc_programming",
+              "label": "PLC Programming challenge"
+            }
+          ]
+        },
+        {
+          "id": "modbus",
+          "title": "Modbus TCP",
+          "summary": "The most common industrial protocol: registers, coils, function codes, and why it trusts every client.",
+          "minutes": 6,
+          "content": "training/theory/foundations/modbus.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "wireshark_capture",
+              "label": "Wireshark capture challenge"
+            },
+            {
+              "type": "ctf",
+              "id": "flood_overwrite",
+              "label": "Flood & overwrite challenge"
+            }
+          ]
+        },
+        {
+          "id": "s7comm",
+          "title": "S7comm",
+          "summary": "Siemens' PLC protocol, its structure, and how enumeration reveals device information.",
+          "minutes": 5,
+          "content": "training/theory/foundations/s7comm.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "scanning2",
+              "label": "S7comm scanning challenge"
+            }
+          ]
+        },
+        {
+          "id": "opcua",
+          "title": "OPC-UA",
+          "summary": "The modern, vendor-neutral protocol with a real security model: sessions, certificates, and users.",
+          "minutes": 6,
+          "content": "training/theory/foundations/opcua.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "opcua",
+              "label": "OPC-UA challenge"
+            }
+          ]
+        },
+        {
+          "id": "hmi-scada",
+          "title": "HMI and SCADA",
+          "summary": "How operators see and control the process, and why the HMI is a high-value target.",
+          "minutes": 5,
+          "content": "training/theory/foundations/hmi-scada.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "password_attack",
+              "label": "Password attack challenge"
+            }
+          ]
+        },
+        {
+          "id": "attack-lifecycle",
+          "title": "The ICS attack lifecycle",
+          "summary": "From reconnaissance to impact, mapped to MITRE ATT&CK for ICS.",
+          "minutes": 7,
+          "content": "training/theory/foundations/attack-lifecycle.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "scanning",
+              "label": "Scanning challenge"
+            },
+            {
+              "type": "ctf",
+              "id": "mitm",
+              "label": "MITM challenge"
+            }
+          ]
+        },
+        {
+          "id": "detection-monitoring",
+          "title": "Detection and monitoring",
+          "summary": "Passive network monitoring, IDS rules, and mapping detections to MITRE D3FEND.",
+          "minutes": 6,
+          "content": "training/theory/foundations/detection-monitoring.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "detect_basic",
+              "label": "Detect basic challenge"
+            },
+            {
+              "type": "ctf",
+              "id": "ids_challenge",
+              "label": "IDS challenge"
+            }
+          ]
+        },
+        {
+          "id": "defense-hardening",
+          "title": "Defense in depth",
+          "summary": "Zones and conduits, IEC 62443 and NIST SP 800-82, and practical hardening.",
+          "minutes": 7,
+          "content": "training/theory/foundations/defense-hardening.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "defense_firewall",
+              "label": "Firewall challenge"
+            },
+            {
+              "type": "ctf",
+              "id": "defense_network_segmentation",
+              "label": "Segmentation challenge"
+            }
+          ]
+        }
+      ]
+    },
+    "modules": {
+      "name": "Per-module background",
+      "icon": "layers",
+      "description": "Short background for each hands-on module and CTF challenge.",
+      "topics": [
+        {
+          "id": "physical_process",
+          "title": "The gas pressure process",
+          "summary": "The plant CybICS models: tanks, compressor, valves, and the safety blowout.",
+          "minutes": 3,
+          "content": "training/theory/modules/physical_process.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "physical_process",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "plc_programming",
+          "title": "Programming the controller",
+          "summary": "Modifying and downloading PLC logic, and why that is a top attack technique.",
+          "minutes": 3,
+          "content": "training/theory/modules/plc_programming.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "plc_programming",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "scanning",
+          "title": "Network scanning",
+          "summary": "Discovering ICS hosts and services with nmap without disrupting them.",
+          "minutes": 3,
+          "content": "training/theory/modules/scanning.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "scanning",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "scanning2",
+          "title": "S7comm enumeration",
+          "summary": "Reading device identity from a Siemens-style S7 endpoint.",
+          "minutes": 3,
+          "content": "training/theory/modules/scanning2.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "scanning2",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "wireshark_capture",
+          "title": "Capturing Modbus traffic",
+          "summary": "Reading plaintext Modbus writes off the wire to recover data.",
+          "minutes": 3,
+          "content": "training/theory/modules/wireshark_capture.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "wireshark_capture",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "flood_overwrite",
+          "title": "Flood and overwrite",
+          "summary": "Overwhelming a register with writes to force an unsafe state.",
+          "minutes": 3,
+          "content": "training/theory/modules/flood_overwrite.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "flood_overwrite",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "password_attack",
+          "title": "Password attacks",
+          "summary": "Dictionary attacks against the OpenPLC and FUXA logins.",
+          "minutes": 3,
+          "content": "training/theory/modules/password_attack.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "password_attack",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "opcua",
+          "title": "Attacking OPC-UA",
+          "summary": "Certificate and user authentication, and what weak auth exposes.",
+          "minutes": 3,
+          "content": "training/theory/modules/opcua.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "opcua",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "fuzzingMB",
+          "title": "Modbus fuzzing",
+          "summary": "Sending malformed and non-standard frames to test robustness.",
+          "minutes": 3,
+          "content": "training/theory/modules/fuzzingMB.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "fuzzingMB",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "mitm",
+          "title": "Man in the middle",
+          "summary": "ARP poisoning between the HMI and the PLC to alter traffic.",
+          "minutes": 3,
+          "content": "training/theory/modules/mitm.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "mitm",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "uart_basic",
+          "title": "UART and hardware access",
+          "summary": "The serial console on the board and physical-layer access.",
+          "minutes": 3,
+          "content": "training/theory/modules/uart_basic.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "uart_basic",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "detect_basic",
+          "title": "Detecting a scan",
+          "summary": "How a port scan looks to an IDS and which rule catches it.",
+          "minutes": 3,
+          "content": "training/theory/modules/detect_basic.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "detect_basic",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "detect_overwrite",
+          "title": "Detecting a flood",
+          "summary": "Spotting a Modbus write flood in the alert stream.",
+          "minutes": 3,
+          "content": "training/theory/modules/detect_overwrite.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "detect_overwrite",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "ids_challenge",
+          "title": "Intrusion detection",
+          "summary": "Generating enough alerts to prove the IDS is working.",
+          "minutes": 3,
+          "content": "training/theory/modules/ids_challenge.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "ids_challenge",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "ids_forensics",
+          "title": "IDS forensics",
+          "summary": "Reading the alert buffer to answer who, what, and when.",
+          "minutes": 3,
+          "content": "training/theory/modules/ids_forensics.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "ids_forensics",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "ids_evasion",
+          "title": "IDS evasion",
+          "summary": "Staying under the rate thresholds a simple rule engine uses.",
+          "minutes": 3,
+          "content": "training/theory/modules/ids_evasion.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "ids_evasion",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "defense_password",
+          "title": "Hardening credentials",
+          "summary": "Removing default passwords on the PLC and HMI.",
+          "minutes": 3,
+          "content": "training/theory/modules/defense_password.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "defense_openplc_password",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "defense_firewall",
+          "title": "Host firewalling",
+          "summary": "Restricting Modbus to authorised peers with iptables.",
+          "minutes": 3,
+          "content": "training/theory/modules/defense_firewall.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "defense_firewall",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "defense_network",
+          "title": "Network segmentation",
+          "summary": "Blocking the attack host from the controllers.",
+          "minutes": 3,
+          "content": "training/theory/modules/defense_network.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "defense_network_segmentation",
+              "label": "Hands-on challenge"
+            }
+          ]
+        },
+        {
+          "id": "defense_ids",
+          "title": "Tuning the IDS",
+          "summary": "Keeping detection active and its rules effective.",
+          "minutes": 3,
+          "content": "training/theory/modules/defense_ids.md",
+          "related": [
+            {
+              "type": "ctf",
+              "id": "defense_ids_tuning",
+              "label": "Hands-on challenge"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/software/landing/utils/config.py
+++ b/software/landing/utils/config.py
@@ -15,6 +15,7 @@ DATA_DIR = os.path.join(BASE_DIR, 'data')
 TRAINING_DIR = os.path.join(BASE_DIR, 'training')
 PROGRESS_FILE = os.path.join(DATA_DIR, 'ctf_progress.json')
 CTF_CONFIG_FILE = os.path.join(BASE_DIR, 'ctf_config.json')
+THEORY_CONFIG_FILE = os.path.join(BASE_DIR, 'theory_config.json')
 
 # Ensure directories exist
 os.makedirs(DATA_DIR, exist_ok=True)

--- a/training/theory/foundations/attack-lifecycle.md
+++ b/training/theory/foundations/attack-lifecycle.md
@@ -1,0 +1,51 @@
+# The ICS attack lifecycle
+
+Real ICS intrusions are not single tricks; they are campaigns with stages. The
+**MITRE ATT&CK for ICS** knowledge base names the tactics an adversary moves through. The
+CybICS challenges are arranged along the same arc, so the CTF is a guided walk through a
+real attack.
+
+<figure>
+<svg viewBox="0 0 560 150" role="img" aria-label="ICS attack lifecycle stages">
+  <defs><marker id="l" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <g font-size="11" text-anchor="middle">
+    <rect x="10" y="40" width="95" height="46" rx="6" fill="#ff6b00" opacity="0.35"/>
+    <text x="57" y="60">Recon</text><text x="57" y="76" font-size="9">scan, enumerate</text>
+    <rect x="125" y="40" width="95" height="46" rx="6" fill="#ff6b00" opacity="0.5"/>
+    <text x="172" y="60">Access</text><text x="172" y="76" font-size="9">creds, MITM</text>
+    <rect x="240" y="40" width="95" height="46" rx="6" fill="#ff6b00" opacity="0.65"/>
+    <text x="287" y="60">Manipulate</text><text x="287" y="76" font-size="9">write, program</text>
+    <rect x="355" y="40" width="95" height="46" rx="6" fill="#ff6b00" opacity="0.8"/>
+    <text x="402" y="60" fill="#1a1a1a">Inhibit</text><text x="402" y="76" font-size="9" fill="#1a1a1a">evade, flood</text>
+    <rect x="470" y="40" width="80" height="46" rx="6" fill="#ff6b00"/>
+    <text x="510" y="60" fill="#1a1a1a">Impact</text><text x="510" y="76" font-size="9" fill="#1a1a1a">blowout</text>
+  </g>
+  <line x1="105" y1="63" x2="123" y2="63" stroke="#ff6b00" stroke-width="2" marker-end="url(#l)"/>
+  <line x1="220" y1="63" x2="238" y2="63" stroke="#ff6b00" stroke-width="2" marker-end="url(#l)"/>
+  <line x1="335" y1="63" x2="353" y2="63" stroke="#ff6b00" stroke-width="2" marker-end="url(#l)"/>
+  <line x1="450" y1="63" x2="468" y2="63" stroke="#ff6b00" stroke-width="2" marker-end="url(#l)"/>
+  <text x="280" y="120" text-anchor="middle" font-size="10" opacity="0.7">Each stage is louder than the last; detection gets easier as impact nears.</text>
+</svg>
+<figcaption>The stages of an ICS attack, and the CybICS challenges that live in each.</figcaption>
+</figure>
+
+## The stages, with CybICS challenges
+
+| Stage | ATT&CK for ICS | CybICS challenge |
+|---|---|---|
+| Discovery | T0846 Remote System Discovery | Scanning, S7comm enumeration |
+| Collection | T0802 Automated Collection | Wireshark capture |
+| Initial access | T0812 Default Credentials, T0859 Valid Accounts | Password attack |
+| Adversary-in-the-middle | T0830 | MITM |
+| Execution / persistence | T0843 Program Download, T0889 Modify Program | PLC programming |
+| Impair process control | T0836 Modify Parameter | Flood & overwrite |
+| Inhibit response / evasion | T0851 Rootkit, evasion of monitoring | IDS evasion |
+| Impact | T0828 Loss of Productivity, unsafe state | The blowout |
+
+## Why the order matters for defenders
+
+Reconnaissance is quiet; impact is obvious. The earlier you detect, the more options you
+have and the less damage is done. That is the whole argument for monitoring the control
+network: it turns a silent campaign into a series of alerts, which is exactly what the
+detection modules practise. The defender's goal is to **shift detection left**, catching the
+scan before it becomes a blowout.

--- a/training/theory/foundations/defense-hardening.md
+++ b/training/theory/foundations/defense-hardening.md
@@ -1,0 +1,74 @@
+# Defense in depth
+
+No single control secures an ICS. The strategy is **defense in depth**: layered controls so
+that getting past one still leaves an attacker facing the next. Two standards frame this for
+OT: **IEC 62443** and **NIST SP 800-82**.
+
+## Zones and conduits
+
+IEC 62443 groups assets into **zones** with similar security needs and controls the
+**conduits** (the connections) between them. The attack machine belongs in a different zone
+from the PLC, and the conduit between them should be tightly restricted.
+
+<figure>
+<svg viewBox="0 0 520 210" role="img" aria-label="Zones and conduits">
+  <g font-size="11" text-anchor="middle">
+    <rect x="20" y="30" width="150" height="150" rx="8" fill="currentColor" opacity="0.10" stroke="currentColor"/>
+    <text x="95" y="24" font-size="11">IT / attacker zone</text>
+    <rect x="45" y="70" width="100" height="40" rx="6" fill="#ff6b00" opacity="0.35"/>
+    <text x="95" y="94">Attack box</text>
+
+    <rect x="350" y="30" width="150" height="150" rx="8" fill="#ff6b00" opacity="0.10" stroke="#ff6b00"/>
+    <text x="425" y="24" font-size="11">Control zone</text>
+    <rect x="375" y="60" width="100" height="36" rx="6" fill="#ff6b00" opacity="0.7"/>
+    <text x="425" y="83" fill="#1a1a1a">PLC</text>
+    <rect x="375" y="110" width="100" height="36" rx="6" fill="#ff6b00" opacity="0.5"/>
+    <text x="425" y="133" fill="#1a1a1a">HMI / OPC-UA</text>
+  </g>
+  <!-- conduit with firewall -->
+  <line x1="170" y1="105" x2="350" y2="105" stroke="currentColor" stroke-width="2"/>
+  <rect x="240" y="88" width="40" height="34" rx="4" fill="#ff6b00"/>
+  <text x="260" y="110" text-anchor="middle" font-size="10" fill="#1a1a1a">FW</text>
+  <text x="260" y="140" text-anchor="middle" font-size="10" opacity="0.8">conduit: only what is needed</text>
+</svg>
+<figcaption>Segmentation puts the attacker and the controllers in different zones, with a firewalled conduit between them. The segmentation and firewall challenges build exactly this boundary.</figcaption>
+</figure>
+
+## Practical hardening in CybICS
+
+The defense challenges implement concrete, verifiable controls:
+
+| Control | What you do | Standard |
+|---|---|---|
+| Remove default credentials | change OpenPLC and FUXA passwords | IEC 62443 SR 1.1; NIST IA-5 |
+| Restrict Modbus | iptables so only the HMI reaches port 502 | SR 5.1; NIST SC-7 |
+| Network segmentation | block the attack host from the controllers | SR 5.1; NIST SC-7 |
+| Keep the IDS effective | detection stays active and tuned | NIST SI-4 |
+
+## Layering the controls
+
+Each control is modest alone; together they compound. Change the passwords and a stolen
+default is worthless. Segment the network and a scan never reaches the PLC. Keep the IDS
+tuned and whatever slips through still raises an alarm.
+
+<figure>
+<svg viewBox="0 0 420 150" role="img" aria-label="Layers of defense">
+  <g text-anchor="middle" font-size="11">
+    <ellipse cx="210" cy="75" rx="200" ry="65" fill="#ff6b00" opacity="0.10" stroke="currentColor"/>
+    <text x="210" y="22">Monitoring / IDS</text>
+    <ellipse cx="210" cy="80" rx="150" ry="50" fill="#ff6b00" opacity="0.14" stroke="currentColor"/>
+    <text x="210" y="46">Segmentation</text>
+    <ellipse cx="210" cy="88" rx="95" ry="34" fill="#ff6b00" opacity="0.25" stroke="#ff6b00"/>
+    <text x="210" y="70">Host firewall</text>
+    <text x="210" y="95" font-weight="bold">Strong auth</text>
+  </g>
+</svg>
+<figcaption>Defense in depth: an attacker must defeat every ring, and the outer ring (monitoring) still reports the attempt.</figcaption>
+</figure>
+
+## The mindset
+
+Assume any single control can fail. Design so that a failure is contained and observed. In
+OT this must be balanced against availability &mdash; a lockout or a dropped packet must
+never endanger the process &mdash; which is why segmentation and monitoring, not intrusive
+blocking, are the workhorses of ICS defense.

--- a/training/theory/foundations/detection-monitoring.md
+++ b/training/theory/foundations/detection-monitoring.md
@@ -1,0 +1,57 @@
+# Detection and monitoring
+
+Because ICS protocols do not authenticate, defenders cannot ask "is this client allowed?".
+Instead they **watch the network** and reason about behaviour. An **Intrusion Detection
+System (IDS)** observes traffic passively and raises alerts when it sees patterns that
+should not occur. CybICS ships a lightweight rule-based IDS.
+
+## Passive monitoring
+
+The IDS sits on a mirror/span of the control network. It never injects packets, so it
+cannot disturb the process &mdash; a hard requirement in OT, where availability is
+paramount.
+
+<figure>
+<svg viewBox="0 0 520 170" role="img" aria-label="Passive IDS on a network tap">
+  <g font-size="11" text-anchor="middle">
+    <rect x="30" y="30" width="90" height="40" rx="6" fill="#ff6b00" opacity="0.7"/>
+    <text x="75" y="54" fill="#1a1a1a">HMI</text>
+    <rect x="400" y="30" width="90" height="40" rx="6" fill="#ff6b00" opacity="0.55"/>
+    <text x="445" y="54" fill="#1a1a1a">PLC</text>
+    <line x1="120" y1="50" x2="400" y2="50" stroke="currentColor" stroke-width="2"/>
+    <text x="260" y="42" font-size="10">Modbus / S7 / OPC-UA traffic</text>
+    <!-- tap -->
+    <line x1="260" y1="50" x2="260" y2="110" stroke="#ff6b00" stroke-dasharray="5 3"/>
+    <rect x="205" y="110" width="110" height="42" rx="6" fill="currentColor" opacity="0.2" stroke="#ff6b00"/>
+    <text x="260" y="130">IDS (passive)</text>
+    <text x="260" y="145" font-size="9">read-only copy</text>
+  </g>
+  <text x="30" y="168" font-size="10" opacity="0.7">The IDS receives a copy of the traffic and never writes to the wire.</text>
+</svg>
+<figcaption>A passive IDS reads a copy of the traffic. It can alert but cannot block, matching OT's availability-first priorities.</figcaption>
+</figure>
+
+## What the rules look for
+
+The CybICS rule engine keeps small sliding-window counters per source and fires named
+rules. Each maps to a MITRE technique:
+
+| Rule | Fires on | ATT&CK for ICS |
+|---|---|---|
+| `port_scan` | many ports probed from one host | T0846 Discovery |
+| `modbus_flood` | burst of Modbus writes | T0814 Denial of Service |
+| `modbus_unauth_write` | writes from an unexpected host | T0855 Unauthorized Command |
+| `modbus_diagnostic` | diagnostic / odd function codes | fuzzing, misuse |
+| `s7_enumeration` | S7comm access | T0846 Discovery |
+| `arp_spoof` | one IP with two MACs | T0830 Adversary-in-the-Middle |
+| `opcua_access` | OPC-UA from a non-client host | unexpected access |
+
+## Detection is not prevention
+
+An alert is only useful if someone acts on it. Defense maps detections to responses. MITRE
+**D3FEND** catalogues the countermeasures: network traffic analysis, protocol-metadata
+anomaly detection, and so on. The detection challenges have you *cause* an attack and then
+*find* it in the alert stream; the tuning challenge keeps the IDS effective.
+
+> **Rule of thumb:** a good ICS detection is specific (few false alarms on normal plant
+> traffic) and tied to a real technique, so an analyst knows what it means and what to do.

--- a/training/theory/foundations/hmi-scada.md
+++ b/training/theory/foundations/hmi-scada.md
@@ -1,0 +1,53 @@
+# HMI and SCADA
+
+The **Human-Machine Interface (HMI)** is the screen an operator watches: tank levels,
+pressures, pumps, alarms, and the buttons to start and stop the process. **SCADA**
+(Supervisory Control and Data Acquisition) is the wider system that gathers data from many
+controllers and presents it. In CybICS the HMI is **FUXA**, a web-based SCADA/HMI.
+
+## Where the HMI sits
+
+The HMI does not talk to sensors directly. It reads and writes the PLC's registers over an
+industrial protocol, and the PLC drives the process. The operator's "start pump" click
+becomes a Modbus write.
+
+<figure>
+<svg viewBox="0 0 520 150" role="img" aria-label="Operator to process data flow">
+  <defs><marker id="h" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <g text-anchor="middle" font-size="11">
+    <rect x="10" y="50" width="90" height="44" rx="6" fill="currentColor" opacity="0.18" stroke="currentColor"/>
+    <text x="55" y="70">Operator</text><text x="55" y="85" font-size="10">eyes &amp; hands</text>
+    <rect x="140" y="50" width="90" height="44" rx="6" fill="#ff6b00" opacity="0.8"/>
+    <text x="185" y="70" fill="#1a1a1a">HMI</text><text x="185" y="85" font-size="10" fill="#1a1a1a">FUXA</text>
+    <rect x="270" y="50" width="90" height="44" rx="6" fill="#ff6b00" opacity="0.6"/>
+    <text x="315" y="70" fill="#1a1a1a">PLC</text><text x="315" y="85" font-size="10" fill="#1a1a1a">OpenPLC</text>
+    <rect x="400" y="50" width="100" height="44" rx="6" fill="#ff6b00" opacity="0.4"/>
+    <text x="450" y="70">Process</text><text x="450" y="85" font-size="10">tanks, valves</text>
+  </g>
+  <line x1="100" y1="72" x2="138" y2="72" stroke="#ff6b00" stroke-width="2" marker-end="url(#h)"/>
+  <line x1="230" y1="72" x2="268" y2="72" stroke="#ff6b00" stroke-width="2" marker-end="url(#h)"/>
+  <text x="250" y="44" text-anchor="middle" font-size="10">Modbus</text>
+  <line x1="360" y1="72" x2="398" y2="72" stroke="#ff6b00" stroke-width="2" marker-end="url(#h)"/>
+  <text x="55" y="120" font-size="10" opacity="0.7">Trust flows right; consequences flow left as displayed values.</text>
+</svg>
+<figcaption>The operator sees the process only through the HMI. Fool the HMI, or the data feeding it, and you control what the operator believes.</figcaption>
+</figure>
+
+## Why the HMI is a high-value target
+
+- It holds **valid credentials** and network paths to the controllers.
+- It can **command** the process directly.
+- The operator **trusts what it shows**. The Stuxnet worm famously replayed normal readings
+  to the HMI while sabotaging the centrifuges underneath &mdash; a lie in the supervisory
+  layer.
+
+In CybICS the FUXA login is a dictionary-attack target (the *password attack* challenge),
+and the man-in-the-middle challenge sits on the HMI-to-PLC link to alter what each side
+sees.
+
+## Security relevance
+
+Protecting the supervisory layer means strong HMI authentication, restricting who can reach
+it, and protecting the integrity of the HMI-to-PLC traffic. When that traffic can be
+altered undetected, the operator's screen becomes untrustworthy &mdash; the most dangerous
+failure in a control room.

--- a/training/theory/foundations/ics-basics.md
+++ b/training/theory/foundations/ics-basics.md
@@ -1,0 +1,84 @@
+# What is an Industrial Control System?
+
+An **Industrial Control System (ICS)** is the combination of hardware and software that
+monitors and controls a physical process: a gas plant, a water works, a power grid, a
+production line. Unlike ordinary IT, an ICS acts on the real world. A wrong value does not
+corrupt a spreadsheet, it opens a valve.
+
+This is why the priorities are inverted compared to IT. In IT the order is usually
+**confidentiality, integrity, availability**. In operational technology (OT) it is the
+reverse: keeping the process running safely comes first.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="IT versus OT priorities">
+  <text x="10" y="24" font-size="13" font-weight="bold">IT priorities</text>
+  <rect x="10" y="34" width="150" height="26" rx="4" fill="#ff6b00" opacity="0.85"/>
+  <text x="20" y="51" font-size="12" fill="#1a1a1a">1. Confidentiality</text>
+  <rect x="170" y="34" width="120" height="26" rx="4" fill="currentColor" opacity="0.25"/>
+  <text x="180" y="51" font-size="12">2. Integrity</text>
+  <rect x="300" y="34" width="120" height="26" rx="4" fill="currentColor" opacity="0.15"/>
+  <text x="310" y="51" font-size="12">3. Availability</text>
+  <text x="10" y="88" font-size="13" font-weight="bold">OT priorities</text>
+  <rect x="10" y="94" width="150" height="26" rx="4" fill="#ff6b00" opacity="0.85"/>
+  <text x="20" y="111" font-size="12" fill="#1a1a1a">1. Safety &amp; Availability</text>
+  <rect x="170" y="94" width="120" height="26" rx="4" fill="currentColor" opacity="0.25"/>
+  <text x="180" y="111" font-size="12">2. Integrity</text>
+  <rect x="300" y="94" width="120" height="26" rx="4" fill="currentColor" opacity="0.15"/>
+  <text x="310" y="111" font-size="12">3. Confidentiality</text>
+</svg>
+<figcaption>The same three goals, ordered differently. In OT, a stopped process can be dangerous and expensive, so availability and safety lead.</figcaption>
+</figure>
+
+## The Purdue model
+
+ICS networks are traditionally described with the **Purdue Enterprise Reference
+Architecture**, a layered model that separates the office from the plant floor. Each level
+talks mostly to its neighbours, and a well-designed plant places security boundaries
+between the levels.
+
+<figure>
+<svg viewBox="0 0 520 320" role="img" aria-label="Purdue model levels">
+  <!-- levels -->
+  <g font-size="12">
+    <rect x="60" y="10" width="400" height="40" rx="5" fill="currentColor" opacity="0.10" stroke="currentColor"/>
+    <text x="72" y="35">Level 4/5 &mdash; Enterprise / IT (ERP, email, internet)</text>
+    <rect x="60" y="60" width="400" height="40" rx="5" fill="currentColor" opacity="0.14" stroke="currentColor"/>
+    <text x="72" y="85">Level 3 &mdash; Operations (historian, engineering workstation)</text>
+    <rect x="60" y="110" width="400" height="40" rx="5" fill="#ff6b00" opacity="0.30" stroke="#ff6b00"/>
+    <text x="72" y="135">Level 2 &mdash; Supervisory (SCADA, HMI)</text>
+    <rect x="60" y="160" width="400" height="40" rx="5" fill="#ff6b00" opacity="0.45" stroke="#ff6b00"/>
+    <text x="72" y="185">Level 1 &mdash; Control (PLCs, controllers)</text>
+    <rect x="60" y="210" width="400" height="40" rx="5" fill="#ff6b00" opacity="0.60" stroke="#ff6b00"/>
+    <text x="72" y="235" fill="#1a1a1a">Level 0 &mdash; Process (sensors, actuators, motors)</text>
+  </g>
+  <!-- DMZ marker -->
+  <line x1="60" y1="105" x2="460" y2="105" stroke="#ff6b00" stroke-dasharray="6 4"/>
+  <text x="60" y="272" font-size="11" opacity="0.8">A security boundary (often an OT DMZ) belongs on the dashed line,</text>
+  <text x="60" y="288" font-size="11" opacity="0.8">between IT above and the control network below.</text>
+</svg>
+<figcaption>The Purdue model. CybICS lives at Levels 0&ndash;2: the physical process, the PLC that controls it, and the HMI that supervises it.</figcaption>
+</figure>
+
+## Where CybICS fits
+
+CybICS is a small but complete ICS. The mapping to the Purdue levels is:
+
+| Purdue level | CybICS component |
+|---|---|
+| Level 2 (Supervisory) | FUXA HMI, and the landing dashboard |
+| Level 1 (Control) | OpenPLC runtime executing the plant program |
+| Level 0 (Process) | The gas pressure process (real on the STM32 board, or simulated) |
+
+The office levels (3&ndash;5) are represented by the engineering workstation and the
+attack machine that sit on the same network for training.
+
+## Why it matters for security
+
+Because these systems were built for reliability, not for hostile networks, most ICS
+protocols have **no authentication and no encryption**. Any host that can reach a PLC can
+usually read and write its values. The rest of the Theory Path shows exactly how each
+protocol works, how that trust is abused, and how to detect and contain it.
+
+> **Key idea:** in ICS security you are protecting a physical process. Every attack in the
+> later modules ends in a real-world effect &mdash; a frozen reading, a forced valve, a
+> blown-out tank.

--- a/training/theory/foundations/modbus.md
+++ b/training/theory/foundations/modbus.md
@@ -1,0 +1,85 @@
+# Modbus TCP
+
+**Modbus** is the lingua franca of industrial automation. It was designed in 1979 for
+serial links and later wrapped in TCP/IP as **Modbus TCP** on port **502**. It is simple,
+open, and everywhere &mdash; and it has no authentication, no encryption, and no integrity
+checking. Whoever can reach port 502 can read and write the controller.
+
+## The data model
+
+Modbus exposes four tables of values. Two are bits, two are 16-bit words:
+
+| Table | Access | Typical use |
+|---|---|---|
+| Coils | read/write | digital outputs (a valve, a motor) |
+| Discrete inputs | read only | digital inputs (a limit switch) |
+| Holding registers | read/write | analogue setpoints, counters |
+| Input registers | read only | sensor readings |
+
+In CybICS the plant's variables live in holding registers: gas storage tank at 1124, high
+pressure tank at 1126, and so on.
+
+## Request and response
+
+A client (the "master") sends a request naming a **function code** and an address; the
+server (the PLC) answers. There is no session and no login.
+
+<figure>
+<svg viewBox="0 0 520 180" role="img" aria-label="Modbus request and response">
+  <rect x="20" y="30" width="120" height="50" rx="6" fill="#ff6b00" opacity="0.85"/>
+  <text x="80" y="52" text-anchor="middle" font-size="12" fill="#1a1a1a" font-weight="bold">Client</text>
+  <text x="80" y="68" text-anchor="middle" font-size="10" fill="#1a1a1a">HMI / attacker</text>
+  <rect x="380" y="30" width="120" height="50" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="440" y="52" text-anchor="middle" font-size="12" font-weight="bold">Server</text>
+  <text x="440" y="68" text-anchor="middle" font-size="10">PLC : 502</text>
+  <defs><marker id="a" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <line x1="140" y1="48" x2="378" y2="48" stroke="#ff6b00" stroke-width="2" marker-end="url(#a)"/>
+  <text x="260" y="42" text-anchor="middle" font-size="11">FC 06: write reg 1126 = 90</text>
+  <line x1="380" y1="72" x2="142" y2="72" stroke="currentColor" stroke-width="2" opacity="0.6" marker-end="url(#a)"/>
+  <text x="260" y="90" text-anchor="middle" font-size="11" opacity="0.8">echo: reg 1126 = 90 (OK)</text>
+  <text x="20" y="130" font-size="11" opacity="0.8">No handshake, no credentials. The server trusts the request because it</text>
+  <text x="20" y="146" font-size="11" opacity="0.8">arrived. This single fact underlies the flood, overwrite and MITM attacks.</text>
+</svg>
+<figcaption>A Modbus write. Function code 6 writes one register; the server applies it and echoes it back. Nothing proves the client is allowed to write.</figcaption>
+</figure>
+
+## The frame
+
+A Modbus TCP message is a 7-byte **MBAP header** followed by the function code and its data.
+
+<figure>
+<svg viewBox="0 0 520 110" role="img" aria-label="Modbus TCP frame layout">
+  <g font-size="10" text-anchor="middle">
+    <rect x="10" y="30" width="70" height="40" fill="currentColor" opacity="0.15" stroke="currentColor"/>
+    <text x="45" y="20" font-size="10">2 B</text><text x="45" y="54">Transaction</text>
+    <rect x="80" y="30" width="70" height="40" fill="currentColor" opacity="0.15" stroke="currentColor"/>
+    <text x="115" y="20">2 B</text><text x="115" y="54">Protocol</text>
+    <rect x="150" y="30" width="70" height="40" fill="currentColor" opacity="0.15" stroke="currentColor"/>
+    <text x="185" y="20">2 B</text><text x="185" y="54">Length</text>
+    <rect x="220" y="30" width="50" height="40" fill="currentColor" opacity="0.15" stroke="currentColor"/>
+    <text x="245" y="20">1 B</text><text x="245" y="54">Unit</text>
+    <rect x="270" y="30" width="60" height="40" fill="#ff6b00" opacity="0.7"/>
+    <text x="300" y="20">1 B</text><text x="300" y="54" fill="#1a1a1a">Func</text>
+    <rect x="330" y="30" width="180" height="40" fill="#ff6b00" opacity="0.35"/>
+    <text x="420" y="20">n B</text><text x="420" y="54">Data (address, values)</text>
+  </g>
+  <text x="10" y="95" font-size="10" opacity="0.7">MBAP header (7 bytes)</text>
+  <text x="420" y="95" font-size="10" opacity="0.7" text-anchor="middle">PDU</text>
+</svg>
+<figcaption>The frame is easy to read and to forge. In the Wireshark challenge you find a flag written byte-by-byte into holding registers.</figcaption>
+</figure>
+
+## Common function codes
+
+- **1/2** read coils / discrete inputs
+- **3/4** read holding / input registers
+- **5/6** write single coil / register
+- **15/16** write multiple coils / registers
+- **8** diagnostics (used by the fuzzing challenge)
+
+## Security relevance
+
+Because Modbus authenticates nothing, the CybICS IDS cannot rely on identity. Instead it
+watches **behaviour**: a burst of writes (flood), writes from an unexpected host
+(unauthorised write), or odd function codes (diagnostics/fuzzing). That is the seam every
+Modbus attack &mdash; and every Modbus detection &mdash; runs through.

--- a/training/theory/foundations/opcua.md
+++ b/training/theory/foundations/opcua.md
@@ -1,0 +1,54 @@
+# OPC-UA
+
+**OPC Unified Architecture (OPC-UA)** is the modern, vendor-neutral standard for industrial
+data exchange, on port **4840**. Unlike Modbus and classic S7comm, OPC-UA was designed with
+security in mind: it has sessions, authentication, and optional signing and encryption. It
+is the protocol you *can* secure &mdash; if it is configured correctly.
+
+## Address space and sessions
+
+OPC-UA models a device as an **address space** of nodes (objects, variables, methods) that
+a client browses. To read or write, a client opens a **secure channel**, then a
+**session**, authenticating as an anonymous, username, or certificate user.
+
+<figure>
+<svg viewBox="0 0 520 200" role="img" aria-label="OPC-UA session establishment">
+  <rect x="20" y="20" width="110" height="44" rx="6" fill="#ff6b00" opacity="0.85"/>
+  <text x="75" y="47" text-anchor="middle" font-size="12" fill="#1a1a1a">Client</text>
+  <rect x="390" y="20" width="110" height="44" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="445" y="42" text-anchor="middle" font-size="12">Server</text>
+  <text x="445" y="56" text-anchor="middle" font-size="10">:4840</text>
+  <defs><marker id="o" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <g font-size="11">
+    <line x1="130" y1="36" x2="388" y2="36" stroke="#ff6b00" stroke-width="2" marker-end="url(#o)"/>
+    <text x="259" y="30" text-anchor="middle">1. OpenSecureChannel (sign / encrypt)</text>
+    <line x1="130" y1="72" x2="388" y2="72" stroke="#ff6b00" stroke-width="2" marker-end="url(#o)"/>
+    <text x="259" y="66" text-anchor="middle">2. CreateSession + ActivateSession (auth)</text>
+    <line x1="130" y1="108" x2="388" y2="108" stroke="#ff6b00" stroke-width="2" marker-end="url(#o)"/>
+    <text x="259" y="102" text-anchor="middle">3. Read / Write / Call on nodes</text>
+  </g>
+  <text x="20" y="150" font-size="11" opacity="0.85">The security level depends on step 1's policy and step 2's identity.</text>
+  <text x="20" y="168" font-size="11" opacity="0.85">"None" policy + anonymous user = an unauthenticated free-for-all.</text>
+</svg>
+<figcaption>OPC-UA establishes a secure channel and an authenticated session before data access. Its safety hinges entirely on which security policy and user token the server accepts.</figcaption>
+</figure>
+
+## Where it goes wrong
+
+OPC-UA can be strong, but defaults and convenience often weaken it:
+
+- **SecurityPolicy None** &mdash; the channel is neither signed nor encrypted, so traffic
+  can be read and forged like Modbus.
+- **Anonymous access** &mdash; no user token required.
+- **Weak or shared passwords**, or certificates trusted too broadly.
+
+The CybICS OPC-UA server exposes both a user-tier and an admin-tier value. The challenge is
+to authenticate well enough to reach the admin flag, illustrating how much rides on the
+identity model.
+
+## Security relevance
+
+OPC-UA shifts the question from "can anyone talk to it" (Modbus) to "who is allowed, and how
+strongly are they proven". Detection focuses on unexpected clients and on sessions using the
+weakest policies. In CybICS, OPC-UA activity from any host that is not a known client raises
+an IDS alert.

--- a/training/theory/foundations/plc-fundamentals.md
+++ b/training/theory/foundations/plc-fundamentals.md
@@ -1,0 +1,89 @@
+# PLCs and the scan cycle
+
+A **Programmable Logic Controller (PLC)** is the small, rugged computer at the heart of a
+control system. It reads sensors, runs a control program, and drives actuators &mdash; over
+and over, thousands of times a minute. In CybICS the PLC role is played by **OpenPLC**.
+
+## The scan cycle
+
+A PLC does not run like a normal program that starts, does work, and exits. It runs a
+**cyclic scan**: an endless loop of three phases repeated every few milliseconds.
+
+<figure>
+<svg viewBox="0 0 420 260" role="img" aria-label="PLC scan cycle">
+  <defs>
+    <marker id="ah" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/>
+    </marker>
+  </defs>
+  <circle cx="210" cy="130" r="95" fill="none" stroke="currentColor" stroke-opacity="0.25" stroke-width="2"/>
+  <!-- three phases -->
+  <g font-size="12" text-anchor="middle">
+    <rect x="150" y="10" width="120" height="42" rx="6" fill="#ff6b00" opacity="0.85"/>
+    <text x="210" y="30" fill="#1a1a1a" font-weight="bold">1. Read inputs</text>
+    <text x="210" y="45" fill="#1a1a1a" font-size="10">sensors &rarr; memory</text>
+
+    <rect x="300" y="150" width="120" height="42" rx="6" fill="#ff6b00" opacity="0.6"/>
+    <text x="360" y="170" fill="#1a1a1a" font-weight="bold">2. Run program</text>
+    <text x="360" y="185" fill="#1a1a1a" font-size="10">logic on the values</text>
+
+    <rect x="0" y="150" width="120" height="42" rx="6" fill="#ff6b00" opacity="0.6"/>
+    <text x="60" y="170" fill="#1a1a1a" font-weight="bold">3. Write outputs</text>
+    <text x="60" y="185" fill="#1a1a1a" font-size="10">memory &rarr; actuators</text>
+  </g>
+  <!-- arrows around -->
+  <path d="M270 40 A95 95 0 0 1 350 150" fill="none" stroke="#ff6b00" stroke-width="2" marker-end="url(#ah)"/>
+  <path d="M300 185 A95 95 0 0 1 120 185" fill="none" stroke="#ff6b00" stroke-width="2" marker-end="url(#ah)"/>
+  <path d="M70 150 A95 95 0 0 1 150 40" fill="none" stroke="#ff6b00" stroke-width="2" marker-end="url(#ah)"/>
+  <text x="210" y="135" text-anchor="middle" font-size="12" opacity="0.7">scan cycle</text>
+  <text x="210" y="152" text-anchor="middle" font-size="11" opacity="0.7">(every few ms)</text>
+</svg>
+<figcaption>One scan: read all inputs into memory, run the whole program on that snapshot, then write all outputs at once. Then repeat.</figcaption>
+</figure>
+
+A consequence worth remembering: the program works on a **snapshot** taken at the start of
+the scan. An output you set is only applied at the end of the cycle. This is why forcing an
+output value from outside (over Modbus, say) is fought by the program: the next scan
+overwrites it with whatever the logic computes.
+
+## IEC 61131-3 languages
+
+PLC programs are written in the languages standardised by **IEC 61131-3**. The two you meet
+in CybICS are:
+
+- **Ladder Diagram (LD)** &mdash; a graphical notation that looks like a relay wiring
+  diagram. Power flows left to right through contacts and coils.
+- **Structured Text (ST)** &mdash; a Pascal-like textual language. The CybICS plant program
+  `cybICS.st` is written in ST.
+
+<figure>
+<svg viewBox="0 0 460 90" role="img" aria-label="A ladder rung">
+  <line x1="20" y1="10" x2="20" y2="80" stroke="currentColor" stroke-width="2"/>
+  <line x1="440" y1="10" x2="440" y2="80" stroke="currentColor" stroke-width="2"/>
+  <line x1="20" y1="45" x2="120" y2="45" stroke="currentColor"/>
+  <!-- normally open contact -->
+  <line x1="120" y1="30" x2="120" y2="60" stroke="currentColor" stroke-width="2"/>
+  <line x1="150" y1="30" x2="150" y2="60" stroke="currentColor" stroke-width="2"/>
+  <text x="112" y="24" font-size="11">start</text>
+  <line x1="150" y1="45" x2="360" y2="45" stroke="currentColor"/>
+  <!-- coil -->
+  <path d="M360 30 A18 15 0 0 0 360 60" fill="none" stroke="#ff6b00" stroke-width="2"/>
+  <path d="M392 30 A18 15 0 0 1 392 60" fill="none" stroke="#ff6b00" stroke-width="2"/>
+  <text x="360" y="24" font-size="11" fill="#ff6b00">motor</text>
+  <line x1="392" y1="45" x2="440" y2="45" stroke="currentColor"/>
+  <text x="20" y="80" font-size="10" opacity="0.7">left rail (power)</text>
+  <text x="392" y="80" font-size="10" opacity="0.7" text-anchor="end">right rail</text>
+</svg>
+<figcaption>A single ladder rung: when the "start" contact is closed, power reaches the "motor" coil and energises it. The CybICS program expresses the same logic in Structured Text.</figcaption>
+</figure>
+
+## How the outside world reaches the PLC
+
+The program's variables are mapped to memory addresses (`%IX`, `%QX`, `%MW` &hellip;) that are
+exposed over industrial protocols. OpenPLC publishes them over Modbus, S7comm, DNP3 and
+EtherNet/IP at the same time. That is convenient for integration &mdash; and, because those
+protocols do not authenticate, convenient for an attacker.
+
+Uploading a **new program** to a running controller is one of the most impactful actions in
+ICS: it changes how the process behaves. That is exactly the *PLC Programming* challenge,
+and it maps to MITRE ATT&CK for ICS **T0843 Program Download**.

--- a/training/theory/foundations/s7comm.md
+++ b/training/theory/foundations/s7comm.md
@@ -1,0 +1,59 @@
+# S7comm
+
+**S7comm** is the proprietary protocol Siemens PLCs use for programming and data exchange.
+It rides on the ISO-on-TCP (RFC 1006) transport on port **102**. CybICS ships a small
+S7comm server so you can practise enumeration without a real Siemens PLC.
+
+## The layered stack
+
+S7comm is not a flat protocol; it is wrapped in two lower layers. Understanding the layers
+explains why a connection needs a setup handshake before any data flows.
+
+<figure>
+<svg viewBox="0 0 360 210" role="img" aria-label="S7comm protocol stack">
+  <g font-size="12" text-anchor="middle">
+    <rect x="80" y="10" width="200" height="34" rx="4" fill="#ff6b00" opacity="0.8"/>
+    <text x="180" y="32" fill="#1a1a1a" font-weight="bold">S7comm (function, data)</text>
+    <rect x="80" y="52" width="200" height="34" rx="4" fill="currentColor" opacity="0.22" stroke="currentColor"/>
+    <text x="180" y="74">COTP (ISO 8073)</text>
+    <rect x="80" y="94" width="200" height="34" rx="4" fill="currentColor" opacity="0.18" stroke="currentColor"/>
+    <text x="180" y="116">TPKT / ISO-on-TCP (RFC 1006)</text>
+    <rect x="80" y="136" width="200" height="34" rx="4" fill="currentColor" opacity="0.14" stroke="currentColor"/>
+    <text x="180" y="158">TCP : 102</text>
+  </g>
+  <text x="180" y="192" font-size="10" opacity="0.7">Each layer wraps the one above; a COTP connection request</text>
+  <text x="180" y="205" font-size="10" opacity="0.7">opens the session before any S7 function is sent.</text>
+</svg>
+<figcaption>The S7comm stack. A client first completes a COTP connection request, then negotiates S7 parameters, then can read data or identity.</figcaption>
+</figure>
+
+## Reading device identity
+
+A useful, low-noise reconnaissance step is the **Read SZL** (System Status List) function.
+It returns identity records: module type, serial number, firmware, plant designation. No
+authentication is needed, so a scanner can fingerprint a Siemens device before touching the
+process. In CybICS the module-type field is where the *scanning2* challenge hides its flag.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="SZL identity query">
+  <rect x="20" y="30" width="110" height="44" rx="6" fill="#ff6b00" opacity="0.85"/>
+  <text x="75" y="57" text-anchor="middle" font-size="12" fill="#1a1a1a">scanner</text>
+  <rect x="390" y="30" width="110" height="44" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="445" y="52" text-anchor="middle" font-size="12">S7 server</text>
+  <text x="445" y="66" text-anchor="middle" font-size="10">:102</text>
+  <defs><marker id="s" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <line x1="130" y1="45" x2="388" y2="45" stroke="#ff6b00" stroke-width="2" marker-end="url(#s)"/>
+  <text x="259" y="39" text-anchor="middle" font-size="11">Read SZL (module identification)</text>
+  <line x1="390" y1="62" x2="132" y2="62" stroke="currentColor" stroke-width="2" opacity="0.6" marker-end="url(#s)"/>
+  <text x="259" y="80" text-anchor="middle" font-size="11" opacity="0.85">Module type, serial, firmware &hellip;</text>
+  <text x="20" y="108" font-size="10" opacity="0.7">Enumeration maps to MITRE ATT&amp;CK for ICS T0846 Remote System Discovery.</text>
+</svg>
+<figcaption>An SZL read returns device identity with no login &mdash; ideal for the attacker's discovery phase, and the basis of the S7comm scanning challenge.</figcaption>
+</figure>
+
+## Security relevance
+
+Classic S7comm (S7-300/400) has no authentication. Newer S7-1200/1500 added S7comm-Plus
+with anti-replay and integrity, but huge installed bases still speak the old protocol.
+Enumeration is quiet and hard to distinguish from legitimate engineering traffic, which is
+why detecting it relies on *where* the request comes from, not *what* it is.

--- a/training/theory/modules/defense_firewall.md
+++ b/training/theory/modules/defense_firewall.md
@@ -1,0 +1,28 @@
+# Host firewalling
+
+Not every host needs to talk Modbus to the PLC &mdash; only the HMI does. A host firewall on
+the controller drops Modbus from everyone else, so an attacker on the network cannot reach
+port 502 at all.
+
+<figure>
+<svg viewBox="0 0 520 130" role="img" aria-label="iptables allowing only the HMI">
+  <defs><marker id="df" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="20" width="90" height="34" rx="6" fill="#ff6b00" opacity="0.55"/><text x="65" y="42" text-anchor="middle" font-size="10" fill="#1a1a1a">HMI (allow)</text>
+  <rect x="20" y="76" width="90" height="34" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/><text x="65" y="98" text-anchor="middle" font-size="10">attacker (deny)</text>
+  <rect x="230" y="45" width="46" height="40" rx="4" fill="#ff6b00"/><text x="253" y="70" text-anchor="middle" font-size="10" fill="#1a1a1a">FW</text>
+  <rect x="380" y="45" width="110" height="40" rx="6" fill="#ff6b00" opacity="0.6"/><text x="435" y="70" text-anchor="middle" font-size="11" fill="#1a1a1a">PLC :502</text>
+  <line x1="110" y1="37" x2="230" y2="55" stroke="#ff6b00" stroke-width="2" marker-end="url(#df)"/>
+  <line x1="110" y1="93" x2="228" y2="75" stroke="currentColor" stroke-width="2" opacity="0.4"/>
+  <line x1="215" y1="60" x2="245" y2="90" stroke="#ff6b00" stroke-width="2"/>
+  <line x1="276" y1="65" x2="380" y2="65" stroke="#ff6b00" stroke-width="2" marker-end="url(#df)"/>
+</svg>
+<figcaption>An iptables rule permits Modbus only from the HMI and drops it from the attack host, shrinking the attack surface to what the process needs.</figcaption>
+</figure>
+
+## The skill
+
+Add iptables rules on the OpenPLC container so only the HMI reaches port 502. The check
+confirms a DROP/REJECT rule for the attack host and that 502 is no longer reachable from
+elsewhere.
+
+> **IEC 62443** SR 5.1; **NIST SP 800-82 / 800-53** SC-7 Boundary Protection.

--- a/training/theory/modules/defense_ids.md
+++ b/training/theory/modules/defense_ids.md
@@ -1,0 +1,27 @@
+# Tuning the IDS
+
+Detection only helps if it is running and its rules actually fire on real attacks. This
+module has you confirm the IDS is healthy, active, and catching the techniques the lab
+throws at it.
+
+<figure>
+<svg viewBox="0 0 520 110" role="img" aria-label="IDS health and active rules">
+  <g font-size="10" text-anchor="middle">
+    <rect x="20" y="35" width="130" height="40" rx="6" fill="#ff6b00" opacity="0.6"/>
+    <text x="85" y="52" fill="#1a1a1a">engine: active</text><text x="85" y="67" fill="#1a1a1a" font-size="9">/health OK</text>
+    <rect x="175" y="35" width="150" height="40" rx="6" fill="currentColor" opacity="0.18" stroke="currentColor"/>
+    <text x="250" y="52">rules with hits &ge; 3</text><text x="250" y="67" font-size="9">scan, flood, unauth&hellip;</text>
+    <rect x="350" y="35" width="150" height="40" rx="6" fill="#ff6b00" opacity="0.35"/>
+    <text x="425" y="58">detection effective</text>
+  </g>
+</svg>
+<figcaption>A healthy IDS: the engine is up and several rules have real hits, so the pipeline is proven end to end.</figcaption>
+</figure>
+
+## The skill
+
+Ensure the IDS service is up and its rules have fired on the attacks you have run. The check
+confirms the engine is active and multiple rules have non-zero hits.
+
+> **NIST SP 800-82 / 800-53** SI-4 System Monitoring. Detection is only a control if it is
+> maintained.

--- a/training/theory/modules/defense_network.md
+++ b/training/theory/modules/defense_network.md
@@ -1,0 +1,28 @@
+# Network segmentation
+
+Segmentation is firewalling raised to the network level: the attacker's zone is cut off from
+the control zone across every service, not just one port. In CybICS you block the attack
+host from both the PLC and the OPC-UA server.
+
+<figure>
+<svg viewBox="0 0 520 150" role="img" aria-label="Segmenting attacker from control zone">
+  <rect x="20" y="30" width="150" height="90" rx="8" fill="currentColor" opacity="0.1" stroke="currentColor"/>
+  <text x="95" y="24" text-anchor="middle" font-size="10">attacker zone</text>
+  <rect x="45" y="60" width="100" height="34" rx="6" fill="#ff6b00" opacity="0.3"/><text x="95" y="82" text-anchor="middle" font-size="10">attack box</text>
+  <rect x="350" y="30" width="150" height="90" rx="8" fill="#ff6b00" opacity="0.1" stroke="#ff6b00"/>
+  <text x="425" y="24" text-anchor="middle" font-size="10">control zone</text>
+  <rect x="370" y="48" width="110" height="28" rx="5" fill="#ff6b00" opacity="0.6"/><text x="425" y="67" text-anchor="middle" font-size="10" fill="#1a1a1a">PLC</text>
+  <rect x="370" y="82" width="110" height="28" rx="5" fill="#ff6b00" opacity="0.5"/><text x="425" y="101" text-anchor="middle" font-size="10" fill="#1a1a1a">OPC-UA</text>
+  <line x1="170" y1="75" x2="350" y2="75" stroke="currentColor" stroke-width="2"/>
+  <line x1="250" y1="55" x2="270" y2="95" stroke="#ff6b00" stroke-width="3"/>
+  <text x="260" y="120" text-anchor="middle" font-size="10" opacity="0.8">no path from the attacker to the controllers</text>
+</svg>
+<figcaption>Segmentation removes the attacker's route to the whole control zone, the boundary the Purdue model and IEC 62443 call for.</figcaption>
+</figure>
+
+## The skill
+
+Apply DROP rules on both the OpenPLC and OPC-UA containers for the attack host, then verify.
+This builds the zone boundary between the attacker and the controllers.
+
+> **IEC 62443** zones and conduits (SR 5.1); **NIST SP 800-82 / 800-53** SC-7.

--- a/training/theory/modules/defense_password.md
+++ b/training/theory/modules/defense_password.md
@@ -1,0 +1,25 @@
+# Hardening credentials
+
+The first control every ICS needs is to remove default and weak passwords. This module has
+you change the OpenPLC and FUXA logins so the earlier dictionary attack no longer works.
+
+<figure>
+<svg viewBox="0 0 520 110" role="img" aria-label="Default versus changed credentials">
+  <rect x="20" y="30" width="210" height="50" rx="6" fill="#ff6b00" opacity="0.2" stroke="#ff6b00"/>
+  <text x="125" y="52" text-anchor="middle" font-size="11">before: admin / default</text>
+  <text x="125" y="70" text-anchor="middle" font-size="10" opacity="0.8">dictionary attack succeeds</text>
+  <text x="250" y="60" font-size="16" fill="#ff6b00">&rarr;</text>
+  <rect x="290" y="30" width="210" height="50" rx="6" fill="currentColor" opacity="0.15" stroke="currentColor"/>
+  <text x="395" y="52" text-anchor="middle" font-size="11">after: strong, unique</text>
+  <text x="395" y="70" text-anchor="middle" font-size="10" opacity="0.8">default login rejected</text>
+</svg>
+<figcaption>Changing the defaults makes stolen or guessed default credentials worthless. The check confirms the old password no longer works.</figcaption>
+</figure>
+
+## The skill
+
+Change the OpenPLC and FUXA passwords through their web UIs, then verify. The check logs in
+with the old defaults and passes only when they are rejected.
+
+> **IEC 62443** SR 1.1; **NIST SP 800-82 / 800-53** IA-5 Authenticator Management. Detection
+> counterpart: HTTP brute-force alerting.

--- a/training/theory/modules/detect_basic.md
+++ b/training/theory/modules/detect_basic.md
@@ -1,0 +1,33 @@
+# Detecting a scan
+
+The scan you ran in reconnaissance is noisy: one host touching many ports in a short time.
+A simple rule engine catches exactly that pattern. This module flips you from attacker to
+defender.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Port scan detection window">
+  <text x="20" y="24" font-size="11">one source, unique ports in a sliding window</text>
+  <g>
+    <rect x="20" y="40" width="360" height="30" rx="4" fill="currentColor" opacity="0.12" stroke="currentColor"/>
+    <g fill="#ff6b00">
+      <rect x="30" y="46" width="10" height="18"/><rect x="55" y="46" width="10" height="18"/>
+      <rect x="80" y="46" width="10" height="18"/><rect x="110" y="46" width="10" height="18"/>
+      <rect x="140" y="46" width="10" height="18"/><rect x="175" y="46" width="10" height="18"/>
+      <rect x="210" y="46" width="10" height="18"/><rect x="250" y="46" width="10" height="18"/>
+    </g>
+    <text x="200" y="64" text-anchor="middle" font-size="9" fill="#1a1a1a"> </text>
+  </g>
+  <text x="400" y="60" font-size="11">&ge; threshold &rarr;</text>
+  <rect x="400" y="70" width="110" height="28" rx="4" fill="#ff6b00" opacity="0.6"/>
+  <text x="455" y="89" text-anchor="middle" font-size="10" fill="#1a1a1a">port_scan alert</text>
+  <text x="20" y="112" font-size="10" opacity="0.7">Counting unique destination ports per source over a time window.</text>
+</svg>
+<figcaption>The port-scan rule counts how many distinct ports a single source probes in a window. Past the threshold, it alerts.</figcaption>
+</figure>
+
+## The skill
+
+Run a scan, open the IDS dashboard, and find the `port_scan` alert. The rule revealing the
+flag proves the detection fired.
+
+> **MITRE D3FEND:** Network Traffic Analysis. Maps to the attacker's T0846 Discovery.

--- a/training/theory/modules/detect_overwrite.md
+++ b/training/theory/modules/detect_overwrite.md
@@ -1,0 +1,24 @@
+# Detecting a flood
+
+A Modbus write flood is even louder than a scan. The IDS counts write function codes per
+source in a short window and alerts when the rate crosses a threshold.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Flood detection rate">
+  <polyline points="20,90 60,88 100,85 140,84 180,50 220,30 260,25 300,24" fill="none" stroke="#ff6b00" stroke-width="2"/>
+  <line x1="20" y1="45" x2="320" y2="45" stroke="currentColor" stroke-dasharray="5 4" opacity="0.5"/>
+  <text x="324" y="48" font-size="10">threshold</text>
+  <text x="20" y="110" font-size="10" opacity="0.7">writes per second from one host over time</text>
+  <rect x="360" y="30" width="150" height="30" rx="4" fill="#ff6b00" opacity="0.6"/>
+  <text x="435" y="49" text-anchor="middle" font-size="10" fill="#1a1a1a">modbus_flood alert</text>
+</svg>
+<figcaption>When the write rate from a single host spikes past the threshold, the flood rule fires.</figcaption>
+</figure>
+
+## The skill
+
+Launch the flood, then read the IDS alert stream for the `modbus_flood` detection that
+carries the flag. Note the rule inspects *write* function codes, so a read flood raises
+nothing &mdash; detections are specific by design.
+
+> **MITRE D3FEND:** Protocol Metadata Anomaly Detection. Maps to T0814 / T0836.

--- a/training/theory/modules/flood_overwrite.md
+++ b/training/theory/modules/flood_overwrite.md
@@ -1,0 +1,33 @@
+# Flood and overwrite
+
+Because Modbus accepts any write, an attacker can hammer a register faster than the process
+logic can correct it, pinning a value or driving the plant into an unsafe state. This is a
+denial-of-control against the process itself.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Write flood">
+  <defs><marker id="fo" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="40" width="90" height="40" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="65" y="64" text-anchor="middle" font-size="11" fill="#1a1a1a">attacker</text>
+  <g stroke="#ff6b00" stroke-width="1.5">
+    <line x1="110" y1="46" x2="392" y2="46" marker-end="url(#fo)"/>
+    <line x1="110" y1="54" x2="392" y2="54" marker-end="url(#fo)"/>
+    <line x1="110" y1="62" x2="392" y2="62" marker-end="url(#fo)"/>
+    <line x1="110" y1="70" x2="392" y2="70" marker-end="url(#fo)"/>
+  </g>
+  <text x="250" y="38" text-anchor="middle" font-size="10">hundreds of writes/second to HPT</text>
+  <rect x="394" y="40" width="100" height="40" rx="6" fill="#ff6b00" opacity="0.6"/>
+  <text x="444" y="64" text-anchor="middle" font-size="11" fill="#1a1a1a">PLC / HPT</text>
+  <text x="20" y="110" font-size="10" opacity="0.7">The flood outruns the control loop, so the register no longer reflects reality.</text>
+</svg>
+<figcaption>A write flood overwhelms the register faster than the scan cycle can restore it, an impairment of process control.</figcaption>
+</figure>
+
+## The skill
+
+Run rapid Modbus writes at the HPT register and watch the process react. In CybICS the flood
+is confirmed by the IDS `modbus_flood` signature, which reveals the flag once the attack is
+observed on the wire.
+
+> **MITRE ATT&CK for ICS:** T0836 Modify Parameter, T0814 Denial of Service. Detection: the
+> *detect a flood* module.

--- a/training/theory/modules/fuzzingMB.md
+++ b/training/theory/modules/fuzzingMB.md
@@ -1,0 +1,30 @@
+# Modbus fuzzing
+
+Fuzzing sends malformed and non-standard messages to see whether a device mishandles them:
+crashes, hangs, or misbehaves. It tests robustness &mdash; and fragile field devices often
+fail badly on input their firmware never expected.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Fuzzing malformed frames">
+  <defs><marker id="fz" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="38" width="90" height="44" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="65" y="64" text-anchor="middle" font-size="11" fill="#1a1a1a">fuzzer</text>
+  <g font-size="9" text-anchor="middle" fill="currentColor">
+    <line x1="110" y1="48" x2="380" y2="48" stroke="#ff6b00" stroke-width="1.4" marker-end="url(#fz)"/>
+    <line x1="110" y1="60" x2="380" y2="60" stroke="#ff6b00" stroke-width="1.4" marker-end="url(#fz)"/>
+    <line x1="110" y1="72" x2="380" y2="72" stroke="#ff6b00" stroke-width="1.4" marker-end="url(#fz)"/>
+    <text x="245" y="40">FC 8 diagnostics, FC 67/68 non-standard, bad lengths</text>
+  </g>
+  <rect x="382" y="38" width="118" height="44" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="441" y="64" text-anchor="middle" font-size="11">Modbus server</text>
+</svg>
+<figcaption>A fuzzer sweeps function codes and field values, including odd and diagnostic codes, watching for a device that copes badly.</figcaption>
+</figure>
+
+## The skill
+
+Run a Modbus fuzzer against port 502, including the diagnostic function codes. In CybICS the
+run is confirmed by the IDS `modbus_diagnostic` signature, which reveals the flag.
+
+> **MITRE ATT&CK for ICS:** exploitation via malformed protocol input. Robust field devices
+> and protocol-aware monitoring are the defence.

--- a/training/theory/modules/ids_challenge.md
+++ b/training/theory/modules/ids_challenge.md
@@ -1,0 +1,27 @@
+# Intrusion detection
+
+This module is about the IDS as a whole: generate enough malicious activity that the system
+recognises it is under attack, and collect the reward for a working detection pipeline.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Alerts accumulating to a threshold">
+  <g fill="#ff6b00" opacity="0.8">
+    <rect x="30" y="70" width="24" height="20"/><rect x="64" y="60" width="24" height="30"/>
+    <rect x="98" y="52" width="24" height="38"/><rect x="132" y="40" width="24" height="50"/>
+  </g>
+  <line x1="20" y1="50" x2="300" y2="50" stroke="currentColor" stroke-dasharray="5 4" opacity="0.5"/>
+  <text x="304" y="53" font-size="10">alert threshold</text>
+  <text x="20" y="108" font-size="10" opacity="0.7">alerts accumulating in the buffer</text>
+  <rect x="360" y="45" width="150" height="30" rx="4" fill="#ff6b00" opacity="0.6"/>
+  <text x="435" y="64" text-anchor="middle" font-size="10" fill="#1a1a1a">flag unlocked</text>
+</svg>
+<figcaption>Once enough alerts accumulate, the IDS confirms an intrusion and releases the flag.</figcaption>
+</figure>
+
+## The skill
+
+Combine the attacks you have learned &mdash; scan, flood, unauthorised writes &mdash; until
+the IDS has logged enough alerts to declare an intrusion. It ties the offensive modules to
+their detections.
+
+> **MITRE D3FEND:** the detection side of the whole attack lifecycle.

--- a/training/theory/modules/ids_evasion.md
+++ b/training/theory/modules/ids_evasion.md
@@ -1,0 +1,27 @@
+# IDS evasion
+
+A rate-based rule only fires above a threshold. An attacker who stays **under** the rate, or
+spreads activity out, can act while raising no alert. Evasion teaches the limits of simple
+detection.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Low and slow under the threshold">
+  <line x1="20" y1="45" x2="420" y2="45" stroke="currentColor" stroke-dasharray="5 4" opacity="0.5"/>
+  <text x="424" y="48" font-size="10">threshold</text>
+  <g fill="#ff6b00" opacity="0.8">
+    <rect x="40" y="70" width="12" height="16"/><rect x="120" y="72" width="12" height="14"/>
+    <rect x="210" y="70" width="12" height="16"/><rect x="300" y="73" width="12" height="13"/>
+    <rect x="380" y="71" width="12" height="15"/>
+  </g>
+  <text x="20" y="108" font-size="10" opacity="0.7">a few writes, well spaced &mdash; each window stays below the line</text>
+</svg>
+<figcaption>Low-and-slow activity keeps every window under the threshold, so the rule never fires even though the attack succeeds.</figcaption>
+</figure>
+
+## The skill
+
+Perform Modbus writes slowly enough that the flood rule never triggers, yet the writes take
+effect. CybICS checks that writes occurred with no new alerts to award the evasion flag.
+
+> **MITRE ATT&CK for ICS:** T0851 and evasion of monitoring. Defence: combine rate rules
+> with anomaly and allow-list detection so "quiet" is not the same as "safe".

--- a/training/theory/modules/ids_forensics.md
+++ b/training/theory/modules/ids_forensics.md
@@ -1,0 +1,26 @@
+# IDS forensics
+
+Detection produces an alert buffer; forensics reads it to answer **who, what, and when**.
+An analyst reconstructs the incident from the recorded alerts rather than the live process.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Alert record fields">
+  <rect x="20" y="30" width="480" height="60" rx="6" fill="currentColor" opacity="0.12" stroke="currentColor"/>
+  <g font-size="10" text-anchor="middle">
+    <text x="90" y="52" font-weight="bold" fill="#ff6b00">timestamp</text><text x="90" y="70">when</text>
+    <text x="210" y="52" font-weight="bold" fill="#ff6b00">source IP</text><text x="210" y="70">who</text>
+    <text x="330" y="52" font-weight="bold" fill="#ff6b00">rule</text><text x="330" y="70">what</text>
+    <text x="450" y="52" font-weight="bold" fill="#ff6b00">target</text><text x="450" y="70">where</text>
+  </g>
+</svg>
+<figcaption>Each alert records the facts an investigator needs. Reading them answers the forensic questions without touching the process.</figcaption>
+</figure>
+
+## The skill
+
+Query the IDS for its alert history and answer questions computed from the buffer: which host
+was most active, which rule fired most, when it started. Correct answers unlock the
+forensics flag.
+
+> **MITRE D3FEND:** Network Traffic Analysis and incident reconstruction. This is the
+> analyst's counterpart to the attacker's noise.

--- a/training/theory/modules/mitm.md
+++ b/training/theory/modules/mitm.md
@@ -1,0 +1,31 @@
+# Man in the middle
+
+If the HMI-to-PLC traffic can be intercepted, an attacker can read and alter it: show the
+operator a normal reading while sending the PLC a different command. On a switched LAN this
+is done with **ARP poisoning**, which redirects traffic through the attacker.
+
+<figure>
+<svg viewBox="0 0 520 150" role="img" aria-label="ARP poisoning MITM">
+  <defs><marker id="mm" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <g text-anchor="middle" font-size="11">
+    <rect x="20" y="55" width="80" height="40" rx="6" fill="#ff6b00" opacity="0.7"/><text x="60" y="79" fill="#1a1a1a">HMI</text>
+    <rect x="420" y="55" width="80" height="40" rx="6" fill="#ff6b00" opacity="0.55"/><text x="460" y="79" fill="#1a1a1a">PLC</text>
+    <rect x="215" y="10" width="90" height="38" rx="6" fill="currentColor" opacity="0.25" stroke="#ff6b00"/>
+    <text x="260" y="33">attacker</text>
+  </g>
+  <line x1="100" y1="70" x2="215" y2="35" stroke="#ff6b00" stroke-width="2" marker-end="url(#mm)"/>
+  <line x1="305" y1="35" x2="420" y2="70" stroke="#ff6b00" stroke-width="2" marker-end="url(#mm)"/>
+  <line x1="100" y1="85" x2="420" y2="85" stroke="currentColor" stroke-dasharray="5 4" opacity="0.4"/>
+  <text x="260" y="105" text-anchor="middle" font-size="10" opacity="0.7">traffic now flows through the attacker, who can alter it</text>
+  <text x="260" y="130" text-anchor="middle" font-size="10" opacity="0.8">one IP appearing with two MAC addresses = the arp_spoof signature</text>
+</svg>
+<figcaption>ARP poisoning inserts the attacker between HMI and PLC. The tell-tale is one IP claimed by two MAC addresses, which the IDS flags.</figcaption>
+</figure>
+
+## The skill
+
+Use `arpspoof` to poison the ARP tables of the HMI and PLC, enable forwarding, and relay (or
+alter) the Modbus traffic. CybICS confirms the attack via the IDS `arp_spoof` signature.
+
+> **MITRE ATT&CK for ICS:** T0830 Adversary-in-the-Middle. Defence: static ARP, segmentation,
+> and integrity-protected protocols.

--- a/training/theory/modules/opcua.md
+++ b/training/theory/modules/opcua.md
@@ -1,0 +1,32 @@
+# Attacking OPC-UA
+
+OPC-UA can be secure, but weak configurations undo it: an anonymous or weakly authenticated
+session may read and write nodes it should not. The challenge is to authenticate well enough
+to reach an admin-tier value.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="OPC-UA node access by tier">
+  <rect x="20" y="30" width="110" height="44" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="75" y="57" text-anchor="middle" font-size="11" fill="#1a1a1a">client</text>
+  <defs><marker id="ou" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <line x1="130" y1="45" x2="360" y2="45" stroke="#ff6b00" stroke-width="2" marker-end="url(#ou)"/>
+  <text x="245" y="39" text-anchor="middle" font-size="10">session as user / admin</text>
+  <g font-size="10" text-anchor="middle">
+    <rect x="362" y="24" width="140" height="26" rx="4" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+    <text x="432" y="41">userFLAG (user tier)</text>
+    <rect x="362" y="58" width="140" height="26" rx="4" fill="#ff6b00" opacity="0.5"/>
+    <text x="432" y="75" fill="#1a1a1a">adminFLAG (admin tier)</text>
+  </g>
+  <text x="20" y="108" font-size="10" opacity="0.7">The tier you reach depends on how you authenticate.</text>
+</svg>
+<figcaption>Different nodes require different privilege. Reaching the admin value shows why the identity model, not the protocol, is what protects OPC-UA.</figcaption>
+</figure>
+
+## The skill
+
+Connect with an OPC-UA client, browse the address space, and authenticate to write the value
+that unlocks the admin flag. Contrast this with Modbus: here there *is* a security model to
+get past.
+
+> **MITRE ATT&CK for ICS:** T0855 Unauthorized Command Message. Background: the OPC-UA
+> foundation topic.

--- a/training/theory/modules/password_attack.md
+++ b/training/theory/modules/password_attack.md
@@ -1,0 +1,32 @@
+# Password attacks
+
+Default and weak credentials are the most common way into ICS web interfaces. A dictionary
+attack tries a wordlist against a login until one works. CybICS has two targets: the OpenPLC
+web UI and the FUXA HMI.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Dictionary attack">
+  <defs><marker id="pw" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="34" width="120" height="52" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="80" y="56" text-anchor="middle" font-size="11" fill="#1a1a1a">ffuf + wordlist</text>
+  <text x="80" y="72" text-anchor="middle" font-size="9" fill="#1a1a1a">rockyou.txt</text>
+  <g font-size="9" text-anchor="middle">
+    <line x1="140" y1="52" x2="380" y2="40" stroke="#ff6b00" stroke-width="1.3" marker-end="url(#pw)"/>
+    <line x1="140" y1="60" x2="380" y2="60" stroke="#ff6b00" stroke-width="1.3" marker-end="url(#pw)"/>
+    <line x1="140" y1="68" x2="380" y2="80" stroke="#ff6b00" stroke-width="1.3" marker-end="url(#pw)"/>
+    <text x="250" y="30">admin : password?</text>
+  </g>
+  <rect x="382" y="40" width="118" height="40" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="441" y="64" text-anchor="middle" font-size="11">login :8080 / :1881</text>
+</svg>
+<figcaption>A dictionary attack submits each candidate password and watches the response length to spot a success.</figcaption>
+</figure>
+
+## The skill
+
+Analyse the login request, then run `ffuf` with a wordlist, filtering by response size or
+content. OpenPLC uses form-encoded POST at `/login`; FUXA uses a JSON API at `/api/signin`.
+Each yields its own flag.
+
+> **MITRE ATT&CK for ICS:** T0812 Default Credentials, T0859 Valid Accounts. Defence: the
+> *harden credentials* module.

--- a/training/theory/modules/physical_process.md
+++ b/training/theory/modules/physical_process.md
@@ -1,0 +1,38 @@
+# The gas pressure process
+
+Every CybICS attack ends in a physical effect, so it pays to know the process. The plant
+moves gas from an external supply into a **Gas Storage Tank (GST)**, compresses it into a
+**High Pressure Tank (HPT)**, and protects itself with a mechanical **blowout** if pressure
+climbs too high.
+
+<figure>
+<svg viewBox="0 0 520 150" role="img" aria-label="Gas pressure process">
+  <defs><marker id="p" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <g text-anchor="middle" font-size="11">
+    <text x="40" y="70" font-size="10">supply</text>
+    <line x1="60" y1="80" x2="110" y2="80" stroke="#ff6b00" stroke-width="2" marker-end="url(#p)"/>
+    <rect x="112" y="55" width="90" height="50" rx="6" fill="#ff6b00" opacity="0.4"/>
+    <text x="157" y="78">GST</text><text x="157" y="93" font-size="9">storage</text>
+    <rect x="235" y="60" width="60" height="40" rx="6" fill="#ff6b00" opacity="0.6"/>
+    <text x="265" y="84" fill="#1a1a1a" font-size="10">compressor</text>
+    <line x1="202" y1="80" x2="233" y2="80" stroke="#ff6b00" stroke-width="2" marker-end="url(#p)"/>
+    <line x1="295" y1="80" x2="326" y2="80" stroke="#ff6b00" stroke-width="2" marker-end="url(#p)"/>
+    <rect x="328" y="55" width="90" height="50" rx="6" fill="#ff6b00" opacity="0.75"/>
+    <text x="373" y="78" fill="#1a1a1a">HPT</text><text x="373" y="93" font-size="9" fill="#1a1a1a">high pressure</text>
+    <line x1="418" y1="70" x2="470" y2="45" stroke="currentColor" stroke-dasharray="4 3" marker-end="url(#p)"/>
+    <text x="470" y="38" font-size="10">blowout</text>
+  </g>
+  <text x="20" y="135" font-size="10" opacity="0.7">The PLC keeps HPT in a safe band; forcing it past critical triggers the blowout.</text>
+</svg>
+<figcaption>The CybICS process. Registers expose GST, HPT, the compressor and the valves &mdash; the same values every protocol attack reads and writes.</figcaption>
+</figure>
+
+## Why it matters
+
+The control logic keeps the HPT within a safe pressure band by running the compressor and
+opening valves. An attacker who overwrites those registers, or the setpoints, can drive the
+tank past its limit &mdash; the `CybICS(Bl0w0ut)` outcome shown on the HMI. Knowing which
+register is which turns a blind write into a targeted one.
+
+> Related: the plant model exists identically in the STM32 firmware and the virtual
+> `hardwareAbstraction.py`, kept in sync by a parity test.

--- a/training/theory/modules/plc_programming.md
+++ b/training/theory/modules/plc_programming.md
@@ -1,0 +1,29 @@
+# Programming the controller
+
+The PLC runs a program you can change. Downloading modified logic to a running controller is
+one of the highest-impact actions in ICS, because it silently changes how the process
+behaves &mdash; the technique behind Stuxnet.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="Program download to PLC">
+  <defs><marker id="pd" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="40" width="140" height="46" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="90" y="62" text-anchor="middle" font-size="11" fill="#1a1a1a">Engineering WS</text>
+  <text x="90" y="77" text-anchor="middle" font-size="9" fill="#1a1a1a">OpenPLC Editor</text>
+  <line x1="160" y1="63" x2="340" y2="63" stroke="#ff6b00" stroke-width="2" marker-end="url(#pd)"/>
+  <text x="250" y="56" text-anchor="middle" font-size="10">compile + download (T0843)</text>
+  <rect x="342" y="40" width="150" height="46" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="417" y="62" text-anchor="middle" font-size="11">OpenPLC runtime</text>
+  <text x="417" y="77" text-anchor="middle" font-size="9">now runs your logic</text>
+</svg>
+<figcaption>Editing the ladder/ST program, compiling it, and downloading it changes the controller's behaviour. The challenge verifies your program is actually running.</figcaption>
+</figure>
+
+## The skill
+
+Open the CybICS project in OpenPLC Editor, modify and compile it, then upload and launch it
+through the web UI. The controller then runs a program that is no longer the shipped one
+&mdash; proof you exercised the program-download workflow.
+
+> **MITRE ATT&CK for ICS:** T0843 Program Download, T0889 Modify Program. Defence:
+> configuration management and change control (NIST CM-3), and integrity verification.

--- a/training/theory/modules/scanning.md
+++ b/training/theory/modules/scanning.md
@@ -1,0 +1,33 @@
+# Network scanning
+
+Reconnaissance comes first. Scanning maps which hosts are alive and which industrial
+services they run, so the attacker knows where the PLC, HMI and protocols live. In OT this
+must be done carefully &mdash; aggressive scans can disturb fragile devices.
+
+<figure>
+<svg viewBox="0 0 520 130" role="img" aria-label="Port scan">
+  <defs><marker id="sc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="45" width="90" height="40" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="65" y="69" text-anchor="middle" font-size="11" fill="#1a1a1a">scanner</text>
+  <g font-size="10" text-anchor="middle">
+    <line x1="110" y1="55" x2="380" y2="25" stroke="#ff6b00" stroke-width="1.5" marker-end="url(#sc)"/>
+    <line x1="110" y1="62" x2="380" y2="55" stroke="#ff6b00" stroke-width="1.5" marker-end="url(#sc)"/>
+    <line x1="110" y1="69" x2="380" y2="85" stroke="#ff6b00" stroke-width="1.5" marker-end="url(#sc)"/>
+    <line x1="110" y1="76" x2="380" y2="115" stroke="#ff6b00" stroke-width="1.5" marker-end="url(#sc)"/>
+    <text x="430" y="28">502 Modbus</text>
+    <text x="430" y="58">102 S7</text>
+    <text x="430" y="88">4840 OPC-UA</text>
+    <text x="430" y="118">8080 web</text>
+  </g>
+  <text x="20" y="120" font-size="10" opacity="0.7">One host probing many ports is the classic scan signature.</text>
+</svg>
+<figcaption>A port scan probes many services on the target. It is fast and informative &mdash; and noisy, which is exactly what the detection module later catches.</figcaption>
+</figure>
+
+## The skill
+
+Use `nmap -sV` to discover hosts and service versions on the lab network. Service banners
+reveal the ICS stack; one of them even carries a flag in its HTTP `Server` header.
+
+> **MITRE ATT&CK for ICS:** T0846 Remote System Discovery. It is loud on purpose here, to
+> connect directly to the *detect a scan* module.

--- a/training/theory/modules/scanning2.md
+++ b/training/theory/modules/scanning2.md
@@ -1,0 +1,28 @@
+# S7comm enumeration
+
+Beyond open ports, an attacker wants device identity: make, model, firmware. S7comm exposes
+this through its System Status List (SZL) with no authentication, letting a scanner
+fingerprint a Siemens-style PLC before touching the process.
+
+<figure>
+<svg viewBox="0 0 520 110" role="img" aria-label="S7 identity enumeration">
+  <defs><marker id="se" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#ff6b00"/></marker></defs>
+  <rect x="20" y="34" width="100" height="44" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="70" y="60" text-anchor="middle" font-size="11" fill="#1a1a1a">enumerator</text>
+  <line x1="120" y1="48" x2="390" y2="48" stroke="#ff6b00" stroke-width="2" marker-end="url(#se)"/>
+  <text x="255" y="42" text-anchor="middle" font-size="10">Read SZL (module id)</text>
+  <line x1="390" y1="66" x2="122" y2="66" stroke="currentColor" stroke-width="2" opacity="0.6" marker-end="url(#se)"/>
+  <text x="255" y="84" text-anchor="middle" font-size="10" opacity="0.85">Module type, serial, firmware</text>
+  <rect x="392" y="34" width="108" height="44" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="446" y="55" text-anchor="middle" font-size="11">S7 server :102</text>
+</svg>
+<figcaption>An SZL read returns identity records. The CybICS S7 server hides the scanning flag in the module-type field.</figcaption>
+</figure>
+
+## The skill
+
+Point an S7 enumeration tool (or nmap S7 script) at port 102 and read the identity records.
+The device fingerprint tells an attacker what exploits and defaults might apply.
+
+> **MITRE ATT&CK for ICS:** T0846 Remote System Discovery. Background: see the S7comm
+> foundation topic.

--- a/training/theory/modules/uart_basic.md
+++ b/training/theory/modules/uart_basic.md
@@ -1,0 +1,32 @@
+# UART and hardware access
+
+Physical access changes everything. Many embedded controllers expose a **UART** serial
+console on the board for debugging. Anyone who can attach to those pins may get a shell, a
+boot log, or a login prompt &mdash; below every network control.
+
+<figure>
+<svg viewBox="0 0 520 120" role="img" aria-label="UART serial console">
+  <rect x="30" y="40" width="150" height="46" rx="6" fill="currentColor" opacity="0.2" stroke="currentColor"/>
+  <text x="105" y="60" text-anchor="middle" font-size="11">STM32 board</text>
+  <text x="105" y="76" text-anchor="middle" font-size="9">TX / RX / GND pins</text>
+  <g stroke="#ff6b00" stroke-width="2">
+    <line x1="180" y1="55" x2="330" y2="55"/>
+    <line x1="180" y1="63" x2="330" y2="63"/>
+    <line x1="180" y1="71" x2="330" y2="71"/>
+  </g>
+  <text x="255" y="46" text-anchor="middle" font-size="9">3 wires</text>
+  <rect x="332" y="40" width="160" height="46" rx="6" fill="#ff6b00" opacity="0.8"/>
+  <text x="412" y="60" text-anchor="middle" font-size="11" fill="#1a1a1a">USB-serial + terminal</text>
+  <text x="412" y="76" text-anchor="middle" font-size="9" fill="#1a1a1a">115200 8N1</text>
+</svg>
+<figcaption>A serial console needs only three wires. It sits beneath the network stack, so it bypasses every network control.</figcaption>
+</figure>
+
+## The skill
+
+Connect to the board's serial console, reach the menu, and get past its simple login. The
+UART flag `CybICS(U#RT)` is printed by the firmware behind that gate. This module is
+hardware-only.
+
+> **MITRE ATT&CK for ICS:** physical/hardware access. Defence: disable or protect debug
+> interfaces, and control physical access to the equipment.

--- a/training/theory/modules/wireshark_capture.md
+++ b/training/theory/modules/wireshark_capture.md
@@ -1,0 +1,29 @@
+# Capturing Modbus traffic
+
+Modbus is plaintext. Anyone who can see the traffic can read every value the HMI and PLC
+exchange &mdash; setpoints, readings, and anything an application writes into registers.
+Traffic capture turns a network position into data.
+
+<figure>
+<svg viewBox="0 0 520 130" role="img" aria-label="Sniffing Modbus writes">
+  <g font-size="10" text-anchor="middle">
+    <rect x="30" y="30" width="80" height="36" rx="6" fill="#ff6b00" opacity="0.7"/><text x="70" y="52" fill="#1a1a1a">HMI</text>
+    <rect x="410" y="30" width="80" height="36" rx="6" fill="#ff6b00" opacity="0.55"/><text x="450" y="52" fill="#1a1a1a">PLC</text>
+    <line x1="110" y1="48" x2="410" y2="48" stroke="currentColor" stroke-width="2"/>
+    <text x="260" y="40">FC16 write regs 1200.. = 43 79 62 49 43 53</text>
+    <line x1="260" y1="48" x2="260" y2="95" stroke="#ff6b00" stroke-dasharray="4 3"/>
+    <rect x="205" y="95" width="110" height="30" rx="5" fill="currentColor" opacity="0.2" stroke="#ff6b00"/>
+    <text x="260" y="114">Wireshark</text>
+  </g>
+  <text x="30" y="125" font-size="10" opacity="0.7">Register bytes decode straight to ASCII: "CybICS(...)".</text>
+</svg>
+<figcaption>Register writes carry bytes that decode to ASCII. Capturing the write packets recovers a flag hidden in holding registers 1200 onward.</figcaption>
+</figure>
+
+## The skill
+
+Capture traffic with Wireshark or tshark, filter for Modbus write function codes, and decode
+the register payloads. The plaintext nature of Modbus is the whole point.
+
+> **MITRE ATT&CK for ICS:** T0802 Automated Collection. Defence: encrypt or segment the
+> control network so capture is not possible from arbitrary hosts.


### PR DESCRIPTION
## What

The **Theory Path** card was a "COMING SOON" placeholder. This implements it as a
full view next to the CTF hub: a sidebar entry and the learning-path card open a
hub of topics, and each topic is an article rendered from Markdown that embeds
inline SVG diagrams.

## Structure (foundations + per-module, as requested)

- **Foundations** — 9 curated, illustrated articles that build up the concepts:
  what an ICS is and the Purdue model, PLCs and the scan cycle, Modbus, S7comm,
  OPC-UA, HMI/SCADA, the ICS attack lifecycle, detection & monitoring, and
  defense in depth.
- **Per-module background** — a short illustrated page for each of the 20
  hands-on modules, each linking to its matching CTF challenge.

## Diagrams

Every article has at least one hand-drawn **inline SVG** (Purdue model, PLC scan
cycle, Modbus frame and request/response, protocol stacks, attack lifecycle,
zones & conduits, defense-in-depth rings, ARP MITM, and more). They use
`currentColor`, so they adapt to both the light and dark themes. No external
assets, so nothing hits the CSP. Content is freshly written and mapped to MITRE
ATT&CK for ICS, D3FEND, IEC 62443 and NIST SP 800-82.

## Mechanics (mirrors the CTF view)

- `theory_config.json` defines the sections and topics.
- `modules/theory_manager.py` renders the Markdown.
- `/theory` (hub) and `/theory/<id>` (article) routes; a `theory` special view,
  nav button, and the enabled learning-path card.
- Read progress tracked client-side in `localStorage`.
- Content under `training/theory/` (already copied into the image); the config is
  copied like `ctf_config.json`.

## Verified

Live in the landing container: all **29 topics** return 200 with a diagram and no
missing-content placeholder; the hub lists them with read tracking; articles
render correctly in both **light and dark** themes (screenshots taken during
development).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
