### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/software/hwio-virtual/hardwareAbstraction.py
+++ b/software/hwio-virtual/hardwareAbstraction.py
@@ -333,7 +333,7 @@ def index_page():
             # "CybICS <version>" from FIRMWARE_VERSION_STRING in
             # software/stm32/src/version.h. That header is the source of
             # truth; this copy has to be bumped alongside it.
-            DISPLAYoverlay1 = ui.label('CybICS v1.2.1').style(
+            DISPLAYoverlay1 = ui.label('CybICS v1.2.2').style(
               'position: absolute; top: 370px; left: 430px; border-radius: 50%; color=black'
               'background-color: transparent; font-size: 40px;'
               'display: block;'

--- a/software/stm32/src/version.h
+++ b/software/stm32/src/version.h
@@ -14,7 +14,7 @@
  */
 #define FIRMWARE_VERSION_MAJOR 1
 #define FIRMWARE_VERSION_MINOR 2
-#define FIRMWARE_VERSION_PATCH 1
+#define FIRMWARE_VERSION_PATCH 2
 
 /* Version as string for display (uses Zephyr's STRINGIFY macro) */
 #define FIRMWARE_VERSION_STRING "v" STRINGIFY(FIRMWARE_VERSION_MAJOR) "." \


### PR DESCRIPTION
## What

Bump the displayed release version to **1.2.2** in the two places that show it:

- `software/hwio-virtual/hardwareAbstraction.py` — the virtual board label
  (`CybICS v1.2.1` &rarr; `CybICS v1.2.2`).
- `software/stm32/src/version.h` — the firmware LCD version (`FIRMWARE_VERSION_PATCH`
  `1` &rarr; `2`).

## Release step (after merge)

The release itself is the git tag. Once this is on `main`:

```
git tag v1.2.2 <merge commit>
git push origin v1.2.2
```

That triggers `rpiImage.yml` (builds and attaches the SD-card image) and the
versioned Docker image build. Cut the tag only when the changes intended for
1.2.2 are merged.

## Verified

The plant-model parity test still passes (the version strings are not part of the
process model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vxcv5CKGvRwXGhAQZqbcP5
